### PR TITLE
Update MR2L3 and MR1L4 state mover to state mover with PMPS

### DIFF
--- a/HOMS_XRT/HOMS_XRT_PLC/POUs/PRG_States.TcPOU
+++ b/HOMS_XRT/HOMS_XRT_PLC/POUs/PRG_States.TcPOU
@@ -61,7 +61,7 @@ VAR
         pv: MR2L3:HOMS:COATING:STATE;
         io: io;
     '}
-    fbMR2L3_Coating_States: FB_Coating_States_noPMPS; 
+    fbMR2L3_Coating_States: FB_Coating_States; 
     
     MR2L3_SiC : DUT_PositionState := (
         bUseRawCounts := TRUE,
@@ -70,7 +70,9 @@ VAR
         sName := 'SiC',  
         nEncoderCount := 9278970,
         fDelta := 1000,
-        fVelocity := 150);
+        fVelocity := 150,
+        stBeamParams := PMPS_GVL.cstFullBeam,
+        nRequestAssertionID := 16#FA82);
         
     MR2L3_W : DUT_PositionState := (
         bUseRawCounts := TRUE,
@@ -79,7 +81,9 @@ VAR
         sName := 'W',  
         nEncoderCount := 19279260,
         fDelta := 1000,
-        fVelocity := 150);
+        fVelocity := 150,
+        stBeamParams := PMPS_GVL.cstFullBeam,
+        nRequestAssertionID := 16#FA83);
     
 //MR1L4 Coating States
     {attribute 'pytmc' := '
@@ -136,6 +140,9 @@ END_VAR
     MR1L3_SiC.stBeamParams.neVRange := F_eVExcludeRange(0, 1000) AND F_eVExcludeRange(13500, 90000);
     MR1L3_W.stBeamParams.neVRange := F_eVExcludeRange(0, 13000) AND F_eVExcludeRange(30000, 90000);
 
+    MR2L3_SiC.stBeamParams.neVRange := F_eVExcludeRange(0, 1000) AND F_eVExcludeRange(13500, 90000);
+    MR2L3_W.stBeamParams.neVRange := F_eVExcludeRange(0, 13000) AND F_eVExcludeRange(30000, 90000);
+    
 //M1L3 States with PMPS
     //Main.M1.bPowerSelf:=FALSE;
     fbMR1L3_Coating_States(
@@ -158,9 +165,14 @@ END_VAR
         
 //MR2L3 States No State PMPS
     fbMR2L3_Coating_States(
+        bBPOkAutoReset := TRUE,
         bEnable := TRUE,
         stCoating1 := MR2L3_SiC,
-        stCoating2 := MR2L3_W,  
+        stCoating2 := MR2L3_W,
+	    fbArbiter:=GVL_PMPS.g_fbArbiter2,
+        fbFFHWO:=GVL_PMPS.g_FastFaultOutput2 ,
+        nTransitionAssertionID:= 16#FA81 , 
+	    nUnknownAssertionID:= 16#FA80 , 
 	    stMotionStage:= Main.M13);
 
 //MR1L4 States No State PMPS


### PR DESCRIPTION
Currently MR2L3 and MR1L4 use `FB_Coating_States_noPMPS` and rely on manual PMPS program block `PRG_CoatingProtection`.

This pull request is en effort to standardize and make consistent the PMPS implementation in the HOMS_XRT project. 

Will move MR2L3 and MR1L4 from `FB_Coating_States_noPMPS` -> `FB_Coating_States` which MR1L3 already uses.