### PR TITLE
Mismatch runtime

### DIFF
--- a/HOMS_XRT/HOMS_XRT.tsproj
+++ b/HOMS_XRT/HOMS_XRT.tsproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
+<?xml version="1.0"?>
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" TcVersionFixed="true">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000002}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..1] OF BIT</Name>
@@ -38,7 +38,7 @@
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{18071995-0000-0000-0000-002000000005}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..4] OF BIT</Name>
+			<Name GUID="{18071995-0000-0000-0000-002000000005}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..4] OF BIT</Name>
 			<BitSize>5</BitSize>
 			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
 			<ArrayInfo>
@@ -51,33 +51,23 @@
 			<BitSize>8</BitSize>
 			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
 			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_MEMORY_NONE]]>
-				</Text>
+				<Text><![CDATA[EAX5000_P_0275_MEMORY_NONE]]></Text>
 				<Enum>0</Enum>
 			</EnumInfo>
 			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]>
-				</Text>
+				<Text><![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]></Text>
 				<Enum>1</Enum>
 			</EnumInfo>
 			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]>
-				</Text>
+				<Text><![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]></Text>
 				<Enum>2</Enum>
 			</EnumInfo>
 			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]>
-				</Text>
+				<Text><![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]></Text>
 				<Enum>8</Enum>
 			</EnumInfo>
 			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]>
-				</Text>
+				<Text><![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]></Text>
 				<Enum>16</Enum>
 			</EnumInfo>
 			<Hides>
@@ -146,7 +136,7 @@
 			<Project File="HOMS_XRT_PLC.xti"/>
 		</Plc>
 		<Io>
-			<Device DevType="111" DevFlags="#x0003" AmsPort="28673" AmsNetId="172.21.88.136.2.1" RemoteName="HOMS" Id="1">
+			<Device Id="1" DevType="111" DevFlags="#x0003" AmsPort="28673" AmsNetId="172.21.88.136.2.1" RemoteName="HOMS">
 				<Name>HOMS</Name>
 				<AddressInfo>
 					<Ccat>
@@ -190,16 +180,16 @@
 				<Image Id="5" AddrType="10" ImageType="3">
 					<Name>Image-3</Name>
 				</Image>
-				<Box BoxType="9099" Id="1">
+				<Box Id="1" BoxType="9099">
 					<Name>Term 1 (EK1200)</Name>
 					<ImageId>1000</ImageId>
 					<EtherCAT PdiType="#x0100" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x04b02c52" RevisionNo="#x00001388" InfoDataState="false" PortPhys="49" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EK1200-5000 EtherCAT Power supply (2A E-Bus)" Desc="EK1200" PortABoxInfo="#x00ffffff"/>
-					<Box BoxType="9099" Id="24">
+					<Box Id="24" BoxType="9099">
 						<Name>Term 24 (EL9187)</Name>
 						<ImageId>1001</ImageId>
 						<EtherCAT CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x23e33050" InfoDataState="false" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL9187 Potential Connection, 8 x Ground" Desc="EL9187" PortABoxInfo="#x01000001"/>
 					</Box>
-					<Box BoxType="9099" Id="13">
+					<Box Id="13" BoxType="9099">
 						<Name>Term 13 (EL2008)</Name>
 						<ImageId>1002</ImageId>
 						<EtherCAT SlaveType="1" PdiType="#x0104" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x07d83052" RevisionNo="#x00120000" RepeatSupport="true" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL2008 8Ch. Dig. Output 24V, 0.5A" Desc="EL2008" PortABoxInfo="#x01000001">
@@ -247,15 +237,15 @@
 							</Pdo>
 						</EtherCAT>
 					</Box>
-					<Box BoxType="9099" Id="14">
+					<Box Id="14" BoxType="9099">
 						<Name>Term 14 (EK1122)</Name>
 						<ImageId>1003</ImageId>
 						<EtherCAT SlaveType="1" PdiType="#x0d00" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x04622c52" RevisionNo="#x00120000" PortPhys="4883" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EK1122 2 port EtherCAT junction" Desc="EK1122" PortABoxInfo="#x0100000d"/>
-						<Box BoxType="9099" Id="6">
+						<Box Id="6" BoxType="9099">
 							<Name>EK1100_M1L3</Name>
 							<ImageId>1004</ImageId>
 							<EtherCAT SlaveType="1" PdiType="#x0d00" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x044c2c52" RevisionNo="#x00120000" PortPhys="305" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EK1100 EtherCAT Coupler (2A E-Bus)" Desc="EK1100" PortABoxInfo="#x0300000e"/>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="7">
+							<Box Id="7" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L3_Xup</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x01000006">
@@ -515,7 +505,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="8">
+							<Box Id="8" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L3_Xdwn</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x01000007">
@@ -775,7 +765,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="9">
+							<Box Id="9" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L3_Yup</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x01000008">
@@ -1035,7 +1025,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="10">
+							<Box Id="10" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L3_Ydwn</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x01000009">
@@ -1295,7 +1285,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="11">
+							<Box Id="11" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L3_PitchCoarse</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x0100000a">
@@ -1558,7 +1548,7 @@
 							<Box File="EL7041-1000_M1L3_Bender.xti" Id="3">
 								<EtherCAT PortABoxInfo="#x0100000b"/>
 							</Box>
-							<Box BoxType="9101" BoxFlags="#x00000020" Id="4">
+							<Box Id="4" BoxType="9101" BoxFlags="#x00000020">
 								<Name>EL6001_M1L3_PitchFine</Name>
 								<ImageId>1006</ImageId>
 								<EtherCAT SlaveType="7" PdiType="#x0005" MboxDataLinkLayer="true" CycleMBoxPolling="true" CoeType="7" FoeType="1" VendorId="#x00000002" ProductCode="#x17713052" RevisionNo="#x00140000" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL6001 Interface (RS232)" Desc="EL6001" PortABoxInfo="#x01000003">
@@ -2382,11 +2372,11 @@
 								<EtherCAT PortABoxInfo="#x01000046"/>
 							</Box>
 						</Box>
-						<Box BoxType="9099" Id="12">
+						<Box Id="12" BoxType="9099">
 							<Name>EK1100_M1L4</Name>
 							<ImageId>1004</ImageId>
 							<EtherCAT SlaveType="1" PdiType="#x0d00" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x044c2c52" RevisionNo="#x00120000" PortPhys="305" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EK1100 EtherCAT Coupler (2A E-Bus)" Desc="EK1100" PortABoxInfo="#x0100000e"/>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="15">
+							<Box Id="15" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L4_Xup</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x0100000c">
@@ -2646,7 +2636,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="16">
+							<Box Id="16" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L4_Xdwn</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x0100000f">
@@ -2906,7 +2896,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="17">
+							<Box Id="17" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L4_Yup</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x01000010">
@@ -3166,7 +3156,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="18">
+							<Box Id="18" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L4_Ydwn</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x01000011">
@@ -3426,7 +3416,7 @@
 									<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
 								</EtherCAT>
 							</Box>
-							<Box BoxType="9099" BoxFlags="#x00000020" Id="19">
+							<Box Id="19" BoxType="9099" BoxFlags="#x00000020">
 								<Name>EL7041-1000_M1L4_PitchCoarse</Name>
 								<ImageId>1005</ImageId>
 								<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b813052" RevisionNo="#x001503e8" InfoDataAddr="true" InfoDataSoeDS401="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7041-1000 1Ch. Stepper motor output stage (50V, 5A, standard)" Desc="EL7041-1000" PortABoxInfo="#x01000012">
@@ -3689,7 +3679,7 @@
 							<Box File="EL7041-1000_M1L4_Bender.xti" Id="20">
 								<EtherCAT PortABoxInfo="#x01000013"/>
 							</Box>
-							<Box BoxType="9101" BoxFlags="#x00000020" Id="21">
+							<Box Id="21" BoxType="9101" BoxFlags="#x00000020">
 								<Name>EL6001_M1L4_PitchFine</Name>
 								<ImageId>1006</ImageId>
 								<EtherCAT SlaveType="7" PdiType="#x0005" MboxDataLinkLayer="true" CycleMBoxPolling="true" CoeType="7" FoeType="1" VendorId="#x00000002" ProductCode="#x17713052" RevisionNo="#x00140000" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL6001 Interface (RS232)" Desc="EL6001" PortABoxInfo="#x01000014">
@@ -4514,7 +4504,7 @@
 							</Box>
 						</Box>
 					</Box>
-					<Box BoxType="9099" Id="2">
+					<Box Id="2" BoxType="9099">
 						<Name>Term 2 (EK1122)</Name>
 						<ImageId>1003</ImageId>
 						<EtherCAT SlaveType="1" PdiType="#x0d00" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x04622c52" RevisionNo="#x00120000" PortPhys="4883" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EK1122 2 port EtherCAT junction" Desc="EK1122" PortABoxInfo="#x0200000e"/>
@@ -4534,11 +4524,11 @@
 		</Io>
 	</Project>
 	<Mappings>
+		<MappingInfo Identifier="{00000000-2001-0850-0020-500830000403}" Id="#x02030010"/>
+		<MappingInfo Identifier="{00000000-2003-0850-0220-500823000403}" Id="#x02030050"/>
+		<MappingInfo Identifier="{00000000-2003-0850-0220-500852000403}" Id="#x02030040"/>
+		<MappingInfo Identifier="{00000000-0040-0304-1000-040341000403}" Id="#x02030020"/>
 		<MappingInfo Identifier="{08502003-0040-0304-0020-500840000403}" Id="#x02030030" Watchdog="00000000000000000000000000000000"/>
 		<MappingInfo Identifier="{05000010-2003-0850-1000-040302205008}" Id="#x02030070" Watchdog="14000000040000000400000004000000"/>
-		<MappingInfo Identifier="{00000000-0040-0304-1000-040341000403}" Id="#x02030020"/>
-		<MappingInfo Identifier="{00000000-2003-0850-0220-500823000403}" Id="#x02030050"/>
-		<MappingInfo Identifier="{00000000-2001-0850-0020-500830000403}" Id="#x02030010"/>
-		<MappingInfo Identifier="{00000000-2003-0850-0220-500852000403}" Id="#x02030040"/>
 	</Mappings>
 </TcSmProject>

--- a/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.plcproj
+++ b/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.plcproj
@@ -362,7 +362,7 @@
       <Resolution>lcls-twincat-motion, 1.8.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-optics">
-      <Resolution>lcls-twincat-optics, 0.6.0 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-optics, 0.6.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.0.14 (SLAC - LCLS)</Resolution>

--- a/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.plcproj
+++ b/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.plcproj
@@ -362,7 +362,7 @@
       <Resolution>lcls-twincat-motion, 1.8.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-optics">
-      <Resolution>lcls-twincat-optics, 0.4.1 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-optics, 0.6.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.0.14 (SLAC - LCLS)</Resolution>

--- a/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
+++ b/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{906953E2-CB65-A20C-D6FA-6F4EC99EF826}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{C007E115-1A1B-DA93-103F-FDB135236BEC}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -527,6 +527,31 @@
         <BitSize>16</BitSize>
         <BitOffs>10416</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -739,6 +764,14 @@
         <Text>_implicit_freewheeling</Text>
         <Enum>3</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>hide</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name>_Implicit_Jitter_Distribution</Name>
@@ -948,6 +981,7 @@
       <Name Namespace="Tc2_Utilities">E_HashPrefixTypes</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Integer to string format prefixes </Comment>
       <EnumInfo>
         <Text>HASHPREFIX_IEC</Text>
         <Enum>0</Enum>
@@ -958,6 +992,12 @@
         <Enum>1</Enum>
         <Comment> 0 for octal type, 0x, 0X for hex else none  </Comment>
       </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">T_MaxString</Name>
+      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
+      <BitSize>2048</BitSize>
+      <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
@@ -1261,6 +1301,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -1308,6 +1373,31 @@
         <BitSize>16</BitSize>
         <BitOffs>96</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -1316,15 +1406,10 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">T_MaxString</Name>
-      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
-      <BitSize>2048</BitSize>
-      <BaseType>STRING(255)</BaseType>
-    </DataType>
-    <DataType>
       <Name Namespace="Tc2_Utilities">E_ArgType</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> String format functions/fb's argument types </Comment>
       <EnumInfo>
         <Text>ARGTYPE_UNKNOWN</Text>
         <Enum>0</Enum>
@@ -1452,6 +1537,7 @@
       <Name Namespace="Tc2_Utilities">E_TypeFieldParam</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> String format argument types </Comment>
       <EnumInfo>
         <Text>TYPEFIELD_UNKNOWN</Text>
         <Enum>0</Enum>
@@ -1919,6 +2005,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -1995,6 +2106,31 @@
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2077,6 +2213,31 @@
         <BitSize>16</BitSize>
         <BitOffs>2320</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2141,6 +2302,31 @@
         <BitSize>2336</BitSize>
         <BitOffs>736</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2214,6 +2400,31 @@
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2288,6 +2499,31 @@
         <BitSize>32</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2518,6 +2754,31 @@
         <BitSize>224</BitSize>
         <BitOffs>4512</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2666,6 +2927,31 @@
         <BitSize>648</BitSize>
         <BitOffs>6256</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2740,6 +3026,31 @@
         <BitSize>32</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2749,7 +3060,7 @@
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Name>
-      <BitSize>27648</BitSize>
+      <BitSize>33248</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
         <Type>BOOL</Type>
@@ -2781,9 +3092,9 @@
       </SubItem>
       <SubItem>
         <Name>i_sCmd</Name>
-        <Type>STRING(80)</Type>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
         <Comment> Command field</Comment>
-        <BitSize>648</BitSize>
+        <BitSize>2048</BitSize>
         <BitOffs>96</BitOffs>
         <Properties>
           <Property>
@@ -2794,10 +3105,10 @@
       </SubItem>
       <SubItem>
         <Name>i_sAxis</Name>
-        <Type>STRING(80)</Type>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
         <Comment> Axis field</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>744</BitOffs>
+        <BitSize>2048</BitSize>
+        <BitOffs>2144</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2807,10 +3118,10 @@
       </SubItem>
       <SubItem>
         <Name>i_sParam</Name>
-        <Type>STRING(80)</Type>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
         <Comment> Parameter field</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>1392</BitOffs>
+        <BitSize>2048</BitSize>
+        <BitOffs>4192</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2823,7 +3134,7 @@
         <Type>BOOL</Type>
         <Comment> Does command have a reply?  Default behavior is the same as the other drivers.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>2040</BitOffs>
+        <BitOffs>6240</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -2838,7 +3149,7 @@
         <Name>q_xDone</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>2048</BitOffs>
+        <BitOffs>6248</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2850,7 +3161,7 @@
         <Name>q_sResponseData</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>2056</BitOffs>
+        <BitOffs>6256</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2862,7 +3173,7 @@
         <Name>q_xError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>2704</BitOffs>
+        <BitOffs>6904</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2874,7 +3185,7 @@
         <Name>q_xTimeout</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>2712</BitOffs>
+        <BitOffs>6912</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2884,9 +3195,9 @@
       </SubItem>
       <SubItem>
         <Name>q_sResult</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>2720</BitOffs>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>6920</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2899,7 +3210,7 @@
         <Type>STRING(80)</Type>
         <Comment> Last String Sent to Serial Device - for debugging </Comment>
         <BitSize>648</BitSize>
-        <BitOffs>3368</BitOffs>
+        <BitOffs>8968</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2912,7 +3223,7 @@
         <Type>STRING(80)</Type>
         <Comment> Last String Received from Serial Device - for debugging </Comment>
         <BitSize>648</BitSize>
-        <BitOffs>4016</BitOffs>
+        <BitOffs>9616</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2924,7 +3235,7 @@
         <Name>iq_stSerialRXBuffer</Name>
         <Type Namespace="Tc2_SerialCom" ReferenceTo="true">ComBuffer</Type>
         <BitSize>32</BitSize>
-        <BitOffs>4672</BitOffs>
+        <BitOffs>10272</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2936,7 +3247,7 @@
         <Name>iq_stSerialTXBuffer</Name>
         <Type Namespace="Tc2_SerialCom" ReferenceTo="true">ComBuffer</Type>
         <BitSize>32</BitSize>
-        <BitOffs>4704</BitOffs>
+        <BitOffs>10304</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -2948,92 +3259,117 @@
         <Name>rtExecute</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>4736</BitOffs>
+        <BitOffs>10336</BitOffs>
       </SubItem>
       <SubItem>
         <Name>iStep</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>4800</BitOffs>
+        <BitOffs>10400</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbClearComBuffer</Name>
         <Type Namespace="Tc2_SerialCom">ClearComBuffer</Type>
         <BitSize>128</BitSize>
-        <BitOffs>4832</BitOffs>
+        <BitOffs>10432</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sSendString</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>4960</BitOffs>
+        <BitOffs>10560</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbFormatString</Name>
         <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
         <BitSize>7840</BitSize>
-        <BitOffs>5632</BitOffs>
+        <BitOffs>11232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>iChecksum</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>13472</BitOffs>
+        <BitOffs>19072</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSendString</Name>
         <Type Namespace="Tc2_SerialCom">SendString</Type>
         <BitSize>3072</BitSize>
-        <BitOffs>13504</BitOffs>
+        <BitOffs>19104</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbReceiveString</Name>
         <Type Namespace="Tc2_SerialCom">ReceiveString</Type>
         <BitSize>6912</BitSize>
-        <BitOffs>16576</BitOffs>
+        <BitOffs>22176</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sReceivedString</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>23488</BitOffs>
+        <BitOffs>29088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>tonTimeout</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>224</BitSize>
-        <BitOffs>24160</BitOffs>
+        <BitOffs>29760</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sRXStringForChecksum</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>24384</BitOffs>
+        <BitOffs>29984</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sReceiveStringWOChecksum</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>25032</BitOffs>
+        <BitOffs>30632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sRXCheckSum</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>25680</BitOffs>
+        <BitOffs>31280</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sRXAddress</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>26328</BitOffs>
+        <BitOffs>31928</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sRXParmNum</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>26976</BitOffs>
+        <BitOffs>32576</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -3043,7 +3379,7 @@
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</Name>
-      <BitSize>104032</BitSize>
+      <BitSize>109632</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
         <Type>BOOL</Type>
@@ -3099,7 +3435,7 @@
       </SubItem>
       <SubItem>
         <Name>q_sResult</Name>
-        <Type>STRING(255)</Type>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
         <BitSize>2048</BitSize>
         <BitOffs>112</BitOffs>
         <Properties>
@@ -3206,20 +3542,20 @@
       <SubItem>
         <Name>fbPITransaction</Name>
         <Type Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Type>
-        <BitSize>27648</BitSize>
+        <BitSize>33248</BitSize>
         <BitOffs>67872</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbFormatString</Name>
         <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
         <BitSize>7840</BitSize>
-        <BitOffs>95520</BitOffs>
+        <BitOffs>101120</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sErrMesg</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>103360</BitOffs>
+        <BitOffs>108960</BitOffs>
         <Default>
           <String>In step %d fbPITransaction failed with message: %s</String>
         </Default>
@@ -3228,7 +3564,7 @@
         <Name>i</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>104016</BitOffs>
+        <BitOffs>109616</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -3242,6 +3578,31 @@
       <Action>
         <Name>a_ClearTrans</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -3350,7 +3711,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity*" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
       <BitSize>16</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
       <EnumInfo>
@@ -3390,6 +3751,7 @@
       <Name Namespace="LCLS_General">E_Subsystem</Name>
       <BitSize>16</BitSize>
       <BaseType>WORD</BaseType>
+      <Comment>LCLS Defined subsystems, make sure these correspond with casSubsystems in FB_LogMessage</Comment>
       <EnumInfo>
         <Text>NILVALUE</Text>
         <Enum>0</Enum>
@@ -3476,31 +3838,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82213644</GetCodeOffs>
+        <GetCodeOffs>82088908</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82213680</GetCodeOffs>
+        <GetCodeOffs>82088944</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82213688</GetCodeOffs>
+        <GetCodeOffs>82088952</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82213668</GetCodeOffs>
+        <GetCodeOffs>82088932</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82213684</GetCodeOffs>
+        <GetCodeOffs>82088948</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -3540,6 +3902,21 @@
         </Properties>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -3552,6 +3929,16 @@
           <Name>nResult</Name>
           <Comment> buffer size in bytes</Comment>
           <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -3671,7 +4058,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}" TcBaseType="true" CName="TcSourceInfoType">TcSourceInfoType</Name>
+      <Name GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}" TcBaseType="true" CName="TcSourceInfoType*">TcSourceInfoType</Name>
       <BitSize>32</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000008}">UDINT</BaseType>
       <EnumInfo>
@@ -3703,7 +4090,7 @@
       </Hides>
     </DataType>
     <DataType>
-      <Name GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" TcBaseType="true" CName="TcSerializedSourceInfoType">TcSerializedSourceInfoType</Name>
+      <Name GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" TcBaseType="true" CName="TcSerializedSourceInfoType*">TcSerializedSourceInfoType</Name>
       <BitSize>96</BitSize>
       <SubItem>
         <Name>eType</Name>
@@ -3864,8 +4251,8 @@
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Properties>
           <Property>
@@ -3874,8 +4261,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getipData</Name>
-        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -3887,8 +4274,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getnId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getnId</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -3901,8 +4288,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getsName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <Name>__getsName</Name>
+        <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
@@ -3920,6 +4307,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -3930,7 +4318,7 @@
       </Method>
     </DataType>
     <DataType>
-      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry">TcEventEntry</Name>
+      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry*">TcEventEntry</Name>
       <BitSize>192</BitSize>
       <SubItem>
         <Name>uuidEventClass</Name>
@@ -3956,8 +4344,8 @@
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc">__geteSeverity</Name>
-        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
+        <Name>__geteSeverity</Name>
+        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
         <Properties>
           <Property>
@@ -3970,8 +4358,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Properties>
           <Property>
@@ -3980,8 +4368,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getipSourceInfo</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
+        <Name>__getipSourceInfo</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -3994,8 +4382,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getnEventId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getnEventId</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -4008,8 +4396,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getsEventClassName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <Name>__getsEventClassName</Name>
+        <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
@@ -4026,8 +4414,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <Name>__getsEventText</Name>
+        <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
@@ -4044,8 +4432,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getstEventEntry</Name>
-        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
+        <Name>__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</ReturnType>
         <ReturnBitSize>192</ReturnBitSize>
         <Properties>
           <Property>
@@ -4055,6 +4443,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4065,6 +4454,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventClass</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4075,6 +4465,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventEntry</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4095,6 +4486,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4120,6 +4512,9 @@
       </Method>
       <Method>
         <Name>RequestEventClassName</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4165,6 +4560,9 @@
       </Method>
       <Method>
         <Name>RequestEventText</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4214,33 +4612,33 @@
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__GetInterfacePointer</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>pRef</Name>
-          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__GetInterfaceReference</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>nInterfaceId</Name>
-          <Type RpcDirection="in">DINT</Type>
+          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>pRef</Name>
-          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
     </DataType>
     <DataType>
-      <Name GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" TcBaseType="true" CName="TcEventArgumentType">TcEventArgumentType</Name>
+      <Name GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" TcBaseType="true" CName="TcEventArgumentType*">TcEventArgumentType</Name>
       <BitSize>16</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
       <EnumInfo>
@@ -4323,6 +4721,14 @@
         <Text>Blob</Text>
         <Enum>19</Enum>
       </EnumInfo>
+      <EnumInfo>
+        <Text>AdsNotificationStream</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UTF8EncodedString</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
       <Properties>
         <Property>
           <Name>plcAttribute_qualified_only</Name>
@@ -4333,6 +4739,7 @@
       </Properties>
       <Hides>
         <Hide GUID="{A1C88D80-AC7F-419E-838D-233C8A8C0184}"/>
+        <Hide GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}"/>
       </Hides>
     </DataType>
     <DataType>
@@ -4355,7 +4762,7 @@
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>eType</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}">TcEventArgumentType</Type>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}">TcEventArgumentType</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -4380,7 +4787,7 @@
         </Parameter>
         <Parameter>
           <Name>eType</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" ReferenceTo="true">TcEventArgumentType</Type>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" ReferenceTo="true">TcEventArgumentType</Type>
           <BitSize X64="64">32</BitSize>
         </Parameter>
         <Parameter>
@@ -4400,7 +4807,7 @@
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>pArgumentTypes</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" PointerTo="1">TcEventArgumentType</Type>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" PointerTo="1">TcEventArgumentType</Type>
           <BitSize X64="64">32</BitSize>
         </Parameter>
       </Method>
@@ -4430,8 +4837,8 @@
       <BitSize>32</BitSize>
       <ExtendsType>IQueryInterface</ExtendsType>
       <Method>
-        <Name RpcEnable="plc">__getipData</Name>
-        <ReturnType GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" RpcDirection="out">ITcArguments</ReturnType>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -4443,8 +4850,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getnCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getnCount</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -4739,18 +5146,21 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82213584</GetCodeOffs>
-        <SetCodeOffs>82213608</SetCodeOffs>
+        <GetCodeOffs>82088844</GetCodeOffs>
+        <SetCodeOffs>82088868</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82213624</GetCodeOffs>
-        <SetCodeOffs>82213636</SetCodeOffs>
+        <GetCodeOffs>82088884</GetCodeOffs>
+        <SetCodeOffs>82088896</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>ExtendName</Name>
+        <Comment> extends the source name on the right side of the string by the given extension.
+ If the source name string size is exceeded nothing more is extended.
+ Function returns TRUE is the concatenation succeeded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4760,8 +5170,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__getipData</Name>
-        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>ipData</Name>
@@ -4797,7 +5207,33 @@
         </Properties>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>ResetToDefault</Name>
+        <Comment> resets the source info to default values (name equals ads symbol name, id equals PLC object id)</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
@@ -4828,10 +5264,10 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__setguid</Name>
+        <Name>__setguid</Name>
         <Parameter>
           <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="in">GUID</Type>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
           <BitSize>128</BitSize>
         </Parameter>
         <Properties>
@@ -4842,6 +5278,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -4851,8 +5288,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Local>
           <Name>guid</Name>
@@ -4946,7 +5383,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTCLASSNAME__FBRESULT</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__FBRESULT</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
         <BitSize>64</BitSize>
         <BitOffs>3232</BitOffs>
@@ -4957,7 +5394,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTCLASSNAME__BBUSY</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__BBUSY</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>3296</BitOffs>
@@ -4968,7 +5405,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTTEXT__FBRESULT</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTTEXT__FBRESULT</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
         <BitSize>64</BitSize>
         <BitOffs>3328</BitOffs>
@@ -4979,7 +5416,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTTEXT__BBUSY</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTTEXT__BBUSY</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>3392</BitOffs>
@@ -4993,40 +5430,41 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>82213736</GetCodeOffs>
+        <GetCodeOffs>82089000</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82213716</GetCodeOffs>
+        <GetCodeOffs>82088980</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82213804</GetCodeOffs>
+        <GetCodeOffs>82089068</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82213808</GetCodeOffs>
+        <GetCodeOffs>82089072</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82213764</GetCodeOffs>
+        <GetCodeOffs>82089028</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82213812</GetCodeOffs>
+        <GetCodeOffs>82089076</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -5106,6 +5544,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -5115,8 +5554,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
-        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>ipEvent</Name>
@@ -5133,8 +5587,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="3">__getEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Local>
           <Name>EventClass</Name>
@@ -5177,8 +5631,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="13">__getstEventEntry</Name>
-        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
+        <Name>__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</ReturnType>
         <ReturnBitSize>192</ReturnBitSize>
         <Local>
           <Name>stEventEntry</Name>
@@ -5198,6 +5652,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventEntry</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -5218,6 +5673,10 @@
       </Method>
       <Method>
         <Name>RequestEventText</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.
+ Result string is UTF-8 encoded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -5267,7 +5726,7 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTTEXT__FBRESULT</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTTEXT__FBRESULT</Value>
             </Property>
           </Properties>
         </Local>
@@ -5278,13 +5737,23 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTTEXT__BBUSY</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTTEXT__BBUSY</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
@@ -5310,8 +5779,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getipArguments</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcArguments</ReturnType>
+        <Name>__getipArguments</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>ipArguments</Name>
@@ -5383,6 +5852,10 @@
       </Method>
       <Method>
         <Name>RequestEventClassName</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.
+ Result string is UTF-8 encoded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -5432,7 +5905,7 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTCLASSNAME__FBRESULT</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__FBRESULT</Value>
             </Property>
           </Properties>
         </Local>
@@ -5443,13 +5916,14 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTCLASSNAME__BBUSY</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__BBUSY</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -5622,7 +6096,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>82213836</GetCodeOffs>
+        <GetCodeOffs>82089104</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -5642,6 +6116,7 @@
       </Method>
       <Method>
         <Name>CreateEx</Name>
+        <Comment> creates a TcCOM event object</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -5714,6 +6189,7 @@
       </Method>
       <Method>
         <Name>Create</Name>
+        <Comment> creates a TcCOM event object</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -5749,8 +6225,33 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
-        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>ipEvent</Name>
@@ -5768,6 +6269,7 @@
       </Method>
       <Method>
         <Name>Send</Name>
+        <Comment> send message to TC EventLogger</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -5779,6 +6281,7 @@
       </Method>
       <Method>
         <Name>Release</Name>
+        <Comment> releases the TcCOM object</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
@@ -5845,6 +6348,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -6188,6 +6716,31 @@
       <Action>
         <Name>CircuitBreaker</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -6256,9 +6809,25 @@
       </EnumInfo>
     </DataType>
     <DataType>
+      <Name>INT (2..100)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>2</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="Tc2_Utilities">E_SBCSType</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Windows SBCS (Single Byte Character Set) Code Pages </Comment>
       <EnumInfo>
         <Text>eSBCS_WesternEuropean</Text>
         <Enum>1</Enum>
@@ -6280,6 +6849,7 @@
       <Name Namespace="Tc2_Utilities">E_RouteTransportType</Name>
       <BitSize>16</BitSize>
       <BaseType>UINT</BaseType>
+      <Comment> TwinCAT route transport types </Comment>
       <EnumInfo>
         <Text>eRouteTransport_None</Text>
         <Enum>0</Enum>
@@ -6518,6 +7088,21 @@
         <BitSize>32</BitSize>
         <BitOffs>832</BitOffs>
       </SubItem>
+    </DataType>
+    <DataType>
+      <Name>UDINT (81..10000)</Name>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>81</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>10000</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.Tc2_TcpIp">ST_SockAddr</Name>
@@ -6786,6 +7371,14 @@
         <Text>Type_Array_WORD</Text>
         <Enum>42</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.TcUnit">ST_TestCaseResult</Name>
@@ -6991,6 +7584,7 @@
       </SubItem>
       <Method>
         <Name>GetAreTestResultsAvailable</Name>
+        <Comment> Returns whether the storing of the test results is finished </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
@@ -6998,6 +7592,31 @@
         <Name>GetTestSuiteResults</Name>
         <ReturnType Namespace="LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -7071,6 +7690,16 @@
         <BitOffs>200</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>TcUnitTestResults</Name>
@@ -7108,6 +7737,21 @@
           <BitSize>648</BitSize>
         </Local>
       </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -7124,6 +7768,19 @@
       <Name Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Name>
       <BitSize>32</BitSize>
       <BaseType>UDINT</BaseType>
+      <Comment> | Access mode
+ | File modes to open a file.
+
+ .. note::
+    For all ``*_PLUS`` modes be aware, that after reading from a file, writing can only be done after a call
+    to |SysFileGetPos| or |SysFileSetPos|! If you call |SysFileWrite| right after |SysFileRead|,
+    the file pointer could be on an invalid position!
+
+    Correct example::
+
+ 	     SysFileRead();
+ 	     SysFileGetPos();
+ 	     SysFileWrite();</Comment>
       <EnumInfo>
         <Text>AM_READ</Text>
         <Enum>0</Enum>
@@ -7154,6 +7811,12 @@
         <Enum>5</Enum>
         <Comment> Open an existing file with Append (read/write) access. If file does not exist, Open creates a new file</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>external_name</Name>
+          <Value>RTS_ACCESS_MODE</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_SIZE</Name>
@@ -7188,7 +7851,20 @@
         <BitOffs>64</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Read</Name>
+        <Comment>
+    Reads a file from disk into the buffer
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -7217,11 +7893,32 @@
       </Method>
       <Method>
         <Name>Close</Name>
+        <Comment>
+    Closes the currently opened file.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Open</Name>
+        <Comment>
+    Opens a file
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -7238,6 +7935,9 @@
       </Method>
       <Method>
         <Name>Delete</Name>
+        <Comment>
+    Deletes a file specified by name, if it exists.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -7249,6 +7949,9 @@
       </Method>
       <Method>
         <Name>Write</Name>
+        <Comment>
+    Writes the contents of the buffer into a file.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -7291,6 +7994,14 @@
         <Text>Error</Text>
         <Enum>3</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_StreamBuffer</Name>
@@ -7365,6 +8076,10 @@
       </Method>
       <Method>
         <Name>Find</Name>
+        <Comment>
+    Find a searchstring in the buffer and returns its position.
+    It's possible to add a preffered startposition within buffer
+</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -7429,8 +8144,26 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="3">__getLength</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>Length</Name>
@@ -7444,7 +8177,20 @@
         </Properties>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
         <Local>
           <Name>Count</Name>
           <Type>UDINT</Type>
@@ -7452,13 +8198,16 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
         <Parameter>
           <Name>Append</Name>
           <Comment>
     Appends a string to the buffer
 </Comment>
-          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
@@ -7478,8 +8227,11 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>BufferSize</Name>
@@ -7493,13 +8245,16 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
         <Parameter>
           <Name>Length</Name>
           <Comment>
     Gets/Sets the current length (in bytes) of the streambuffer
 </Comment>
-          <Type RpcDirection="in">UDINT</Type>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Properties>
@@ -7527,6 +8282,9 @@
       </Method>
       <Method>
         <Name>Copy</Name>
+        <Comment>
+    Copies a string from the character buffer
+</Comment>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -7767,6 +8525,11 @@
       </SubItem>
       <Method>
         <Name>NewParameter</Name>
+        <Comment>
+    Must be called after opening a new tag
+
+    XML.NewParameter(Name: = 'ParaName', Value: = 'Value');
+</Comment>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -7779,7 +8542,28 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
+        <Comment>
+    Creates a new Tag:
+    XML: &lt;MyTag&gt;
+
+    XML.NewTag(Name: = 'MyTag');
+</Comment>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -7788,6 +8572,12 @@
       </Method>
       <Method>
         <Name>CloseTag</Name>
+        <Comment>
+    Closes a Tag:
+    XML: &lt;MyTag /&gt;'
+
+    Method: XML.CloseTag();
+</Comment>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Local>
@@ -7798,6 +8588,14 @@
       </Method>
       <Method>
         <Name>WriteDocumentHeader</Name>
+        <Comment>
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+</Comment>
         <Parameter>
           <Name>Header</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -7806,6 +8604,12 @@
       </Method>
       <Method>
         <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
         <Parameter>
           <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -7813,8 +8617,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__getLength</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getLength</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>Length</Name>
@@ -7826,6 +8630,16 @@
             <Name>property</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>NewTagData</Name>
@@ -7852,9 +8666,16 @@
       </Method>
       <Method>
         <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
       </Method>
       <Method>
         <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
       </Method>
       <Properties>
         <Property>
@@ -7932,11 +8753,31 @@
       </SubItem>
       <Method>
         <Name>DeleteOpenWriteClose</Name>
+        <Comment>
+    Deletes the former file (if it exists).
+    Opens the file, writes the buffer and closes it.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>LogTestSuiteResults</Name>
+        <Comment>
+    This method is responsible for the entire generation of the output file. 
+    The output of the xml writer is NOT beautified.
+    
+    When new data is available, feel free to add it to the report
+</Comment>
         <Local>
           <Name>UnitTestResults</Name>
           <Type Namespace="LCLS_General.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
@@ -7967,6 +8808,21 @@
           <Type>STRING(80)</Type>
           <BitSize>648</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>Initialised</Name>
@@ -8049,7 +8905,7 @@
         <BitOffs>621826912</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Name>
+        <Name>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Name>
         <Type>UINT</Type>
         <Comment> This variable holds which current test suite is being called, as we are running
        each one in a sequence (one by one) </Comment>
@@ -8060,16 +8916,44 @@
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Name>
+        <Name>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Name>
         <Type Namespace="Tc2_Standard">TOF</Type>
         <BitSize>224</BitSize>
         <BitOffs>621826976</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AbortRunningTestSuiteTests</Name>
+        <Comment> This function sets a flag which makes the runner stop running the tests
+   in the test suites </Comment>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>RunTestSuiteTestsInSequence</Name>
+        <Comment> This runs all the test suites in sequence (one after the other) </Comment>
         <Parameter>
           <Name>TimeBetweenTestSuitesExecution</Name>
           <Comment> Time delay between a test suite is finished and the next test suite starts</Comment>
@@ -8099,7 +8983,7 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Value>
+              <Value>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Value>
             </Property>
           </Properties>
         </Local>
@@ -8110,13 +8994,14 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Value>
+              <Value>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>RunTestSuiteTests</Name>
+        <Comment> This runs all the test suites in parallel </Comment>
         <Local>
           <Name>Counter</Name>
           <Type>UINT</Type>
@@ -8206,6 +9091,21 @@
         <BitOffs>4184</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetAssertionType</Name>
         <ReturnType Namespace="LCLS_General.TcUnit">E_AssertionType</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -8235,7 +9135,18 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetTestOrder</Name>
+        <Comment> Sets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
         <Parameter>
           <Name>OrderNumber</Name>
           <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
@@ -8264,9 +9175,11 @@
       </Method>
       <Method>
         <Name>SetSkipped</Name>
+        <Comment> Sets the test case to skipped </Comment>
       </Method>
       <Method>
         <Name>SetAssertionMessage</Name>
+        <Comment> Sets the assertion message. If one already exists, it's not overwritten as we keep the first assertion in the test </Comment>
         <Parameter>
           <Name>AssertMessage</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -8275,6 +9188,7 @@
       </Method>
       <Method>
         <Name>SetAssertionType</Name>
+        <Comment> Sets the assertion type. If one already exists, it's not overwritten as we keep the first assertion in the test </Comment>
         <Parameter>
           <Name>AssertType</Name>
           <Type Namespace="LCLS_General.TcUnit">E_AssertionType</Type>
@@ -8288,6 +9202,7 @@
       </Method>
       <Method>
         <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
         <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
@@ -8478,6 +9393,17 @@
         <Text>TYPE_BITCONST</Text>
         <Enum>38</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>m4export_hide</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name>AnyType</Name>
@@ -8521,6 +9447,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -8559,6 +9510,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -8731,8 +9707,13 @@
       </EnumInfo>
       <EnumInfo>
         <Text>TYPE_INTERFACE</Text>
-        <Enum>-4096</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>compatibility_id</Name>
+          <Value>52A6FD6D-031C-41c0-A818-0F45FE19AF8F</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.TcUnit">U_ExpectedOrActual</Name>
@@ -8995,6 +9976,16 @@
         <BitOffs>24640288</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -9021,6 +10012,21 @@
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
@@ -9172,6 +10178,33 @@
       </Method>
       <Method>
         <Name>ReportResult</Name>
+        <Comment>
+    This method is called in every assert and returns whether this particular assert has already been called.
+    The reason one would like to know whether this assert has already been reported or not is to not report it several
+    times to any logging service. Because a test-suite can consist of several tests, and certain tests can require the
+    test to run over several cycles it means that certain asserts could be called several times and thus we need to
+    keep track of which asserts we've already reported. The user of the framework should not need to care for any of
+    this and he/she should be able to call the asserts in any way they find suitable.
+
+    To know what assert this is we need to check for the total combination of:
+    - Test message
+    - Test instance path
+    - Expected value
+    - Actual value
+    Theoretically we can have a situation where a test has three different asserts, each and one with the same test
+    message/test instance path/actual value/expected value but called within the same or different cycles. In order for
+    us to handle all situations we need a simple algorithm that works according to:
+    - Keep track of how many instances the combination of test message/test instance path/expected value/actual value
+      we have. So for example, if we have called Assert(Exp := 5, Act := 5, 'Hello there', 'PRG.InstanceTestSuite.Test')
+      two times in one cycle, we have two instances of that combination. This is done according to:
+    - Iterate all existing reports.
+      - If we have a new PLC-cycle, set the current detection-count to zero.
+      - If new report does not match in any of the above fields, create it (together with current PLC-cycle).
+        Also store the information that we have one instance of this combination and +1 on the detection-count.
+      - If new report matches in all of the above, +1 in the detection-count. If this detection-count is larger than
+        the stored detection-count for this combination, create a new report and add +1 to the storage of
+        the detection-count.
+</Comment>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -9456,6 +10489,31 @@
         <BitOffs>8480224</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -9575,6 +10633,36 @@
       </Method>
       <Method>
         <Name>ReportResult</Name>
+        <Comment>
+    This method is called in every assert and returns whether this particular assert has already been called.
+    The reason one would like to know whether this assert has already been reported or not is to not report it several
+    times to any logging service. Because a test-suite can consist of several tests, and certain tests can require the
+    test to run over several cycles it means that certain asserts could be called several times and thus we need to
+    keep track of which asserts we've already reported. The user of the framework should not need to care for any of
+    this and he/she should be able to call the asserts in any way they find suitable.
+
+    To know what assert this is we need to check for the total combination of:
+    - Test message
+    - Test instance path
+    - Expecteds size (in bytes)
+    - Actuals size (in bytes)
+    - Expecteds datatype
+    - Actuals datatype
+    Theoretically we can have a situation where a test has three different asserts, each and one with the same test
+    message/test instance path/actuals size&amp;datatype/expecteds size&amp;datatype but called within the same or different
+    cycles. In order for us to handle all situations we need a simple algorithm that works according to:
+    - Keep track of how many instances the combination of test message/test instance path/expecteds size&amp;datatype/
+      actuals size&amp;datatype we have. So for example, if we have called
+      Assert(Exp := [5,4,3], Act := [5,4,3], 'Hello there', 'PRG.InstanceTestSuite.Test')
+      two times in one cycle, we have two instances of that combination. This is done according to:
+    - Iterate all existing reports.
+      - If we have a new PLC-cycle, set the current detection-count to zero.
+      - If new report does not match in any of the above fields, create it (together with current PLC-cycle).
+        Also store the information that we have one instance of this combination and +1 on the detection-count.
+      - If new report matches in all of the above, +1 in the detection-count. If this detection-count is larger than
+        the stored detection-count for this combination, create a new report and add +1 to the storage of
+        the detection-count.
+</Comment>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -9849,6 +10937,31 @@
           <Value>253</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -9865,6 +10978,31 @@
 </Comment>
       <BitSize>64</BitSize>
       <Implements Namespace="LCLS_General.TcUnit">I_AssertMessageFormatter</Implements>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Method>
         <Name>LogAssertFailure</Name>
         <Parameter>
@@ -10042,6 +11180,9 @@
       </SubItem>
       <Method>
         <Name>AssertEquals_LINT</Name>
+        <Comment>
+    Asserts that two LINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LINT expected value</Comment>
@@ -10078,6 +11219,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> ULINT array with expected values</Comment>
@@ -10169,19 +11313,18 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_TIME</Name>
+        <Comment>
+    Asserts that two TIMEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> TIME expected value</Comment>
@@ -10213,6 +11356,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_TIME_OF_DAY</Name>
+        <Comment>
+    Asserts that two TIME_OF_DAYs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> TIME_OF_DAY expected value</Comment>
@@ -10244,6 +11390,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> BYTE expected value</Comment>
@@ -10274,6 +11423,21 @@
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetNumberOfFailedTests</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
@@ -10300,6 +11464,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_DATE_AND_TIME</Name>
+        <Comment>
+    Asserts that two DATE_AND_TIMEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DATE_AND_TIME expected value</Comment>
@@ -10331,6 +11498,7 @@
       </Method>
       <Method>
         <Name>GetTestByPosition</Name>
+        <Comment> This method returns the test at the n'th position, ranging from 1.. NumberOfTests </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit">FB_Test</ReturnType>
         <ReturnBitSize>4192</ReturnBitSize>
         <Parameter>
@@ -10341,6 +11509,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOL arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> BOOL array with expected values</Comment>
@@ -10432,14 +11603,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> BYTE array with expected values</Comment>
@@ -10541,14 +11710,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DATE</Name>
+        <Comment>
+    Asserts that two DATEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DATE expected value</Comment>
@@ -10580,6 +11747,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_WORD</Name>
+        <Comment>
+    Asserts that two WORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> WORD expected value</Comment>
@@ -10611,6 +11781,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_LINT</Name>
+        <Comment>
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LINT array with expected values</Comment>
@@ -10702,14 +11875,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LTIME</Name>
+        <Comment>
+    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LTIME expected value</Comment>
@@ -10741,6 +11912,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_UINT</Name>
+        <Comment>
+    Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> UINT array with expected values</Comment>
@@ -10832,14 +12006,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREALs are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LREAL expected value</Comment>
@@ -10877,6 +12049,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORD arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LWORD array with expected values</Comment>
@@ -10978,14 +12153,14 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals</Name>
+        <Comment>
+    Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
+    For REAL and LREAL it's recommended to use the AssertEquals_REAL or AssertEquals_LREAL respectively
+    as these give the possibility to specify a delta between the expected and actual value.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> Expected value</Comment>
@@ -11292,6 +12467,9 @@
       </Method>
       <Method>
         <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Condition</Name>
           <Comment> Condition to be checked</Comment>
@@ -11307,6 +12485,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> SINT expected value</Comment>
@@ -11338,6 +12519,9 @@
       </Method>
       <Method>
         <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LREAL 2d array with expected values</Comment>
@@ -11526,6 +12710,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> ULINT expected value</Comment>
@@ -11557,6 +12744,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> BOOL expected value</Comment>
@@ -11588,6 +12778,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> USINT expected value</Comment>
@@ -11619,6 +12812,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LWORD expected value</Comment>
@@ -11650,6 +12846,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> USINT array with expected values</Comment>
@@ -11741,11 +12940,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>SetHasStartedRunning</Name>
@@ -11805,6 +12999,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORD arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> DWORD array with expected values</Comment>
@@ -11906,11 +13103,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetHasStartedRunning</Name>
@@ -11919,6 +13111,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LREAL array with expected values</Comment>
@@ -12016,14 +13211,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_WSTRING</Name>
+        <Comment>
+    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> WSTRING expected value</Comment>
@@ -12075,6 +13268,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> REAL array with expected values</Comment>
@@ -12172,14 +13368,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DINT expected value</Comment>
@@ -12211,6 +13405,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> DINT array with expected values</Comment>
@@ -12302,14 +13499,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_STRING</Name>
+        <Comment>
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> STRING expected value</Comment>
@@ -12341,6 +13536,9 @@
       </Method>
       <Method>
         <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -12381,6 +13579,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_WORD</Name>
+        <Comment>
+    Asserts that two WORD arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> WORD array with expected values</Comment>
@@ -12482,14 +13683,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LREAL 3d array with expected values</Comment>
@@ -12678,6 +13877,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_INT</Name>
+        <Comment>
+    Asserts that two INT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> INT array with expected values</Comment>
@@ -12769,11 +13971,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>CalculateAndSetNumberOfAssertsForTest</Name>
@@ -12830,6 +14027,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DWORD expected value</Comment>
@@ -12861,6 +14061,9 @@
       </Method>
       <Method>
         <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Condition</Name>
           <Comment> Condition to be checked</Comment>
@@ -12876,6 +14079,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
+        <Comment>
+    Asserts that two INTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> INT expected value</Comment>
@@ -12907,6 +14113,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_UINT</Name>
+        <Comment>
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> UINT expected value</Comment>
@@ -12937,7 +14146,20 @@
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AssertArray2dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> REAL 2d array with expected values</Comment>
@@ -13189,6 +14411,9 @@
       </Method>
       <Method>
         <Name>AssertArray3dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> REAL 3d array with expected values</Comment>
@@ -13408,6 +14633,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_UDINT</Name>
+        <Comment>
+    Asserts that two UDINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> UDINT expected value</Comment>
@@ -13439,6 +14667,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_REAL</Name>
+        <Comment>
+    Asserts that two REALs are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> REAL expected value</Comment>
@@ -13476,6 +14707,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> SINT array with expected values</Comment>
@@ -13567,14 +14801,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_UDINT</Name>
+        <Comment>
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> UDINT array with expected values</Comment>
@@ -13663,11 +14895,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -13944,6 +15171,31 @@
       <Action>
         <Name>A_GetHead</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14012,12 +15264,23 @@
         </Default>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>WriteLog</Name>
+        <Comment> Writes a new data set into the ring buffer </Comment>
         <Parameter>
           <Name>MsgCtrlMask</Name>
           <Type>DWORD</Type>
@@ -14053,6 +15316,7 @@
       </Method>
       <Method>
         <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
         <Parameter>
           <Name>AdsLogStringMessage</Name>
           <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
@@ -14075,6 +15339,21 @@
               <Value>Output</Value>
             </Property>
           </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -14650,6 +15929,31 @@
  Workaround for compile defines not fully working for libraries at the time of writing this.
  Otherwise I would have just used the compile define in the GVL declaration.</Comment>
       <BitSize>32</BitSize>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14855,7 +16159,23 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
@@ -14884,7 +16204,18 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14961,8 +16292,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__get_ipWriter</Name>
-        <ReturnType GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}" RpcDirection="out">ITcJsonSaxWriter</ReturnType>
+        <Name>__get_ipWriter</Name>
+        <ReturnType GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}">ITcJsonSaxWriter</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>_ipWriter</Name>
@@ -14996,6 +16327,7 @@
       </Method>
       <Method>
         <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -15071,6 +16403,7 @@
       </Method>
       <Method>
         <Name>CopyDocument</Name>
+        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -16900,6 +18233,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -17200,6 +18558,31 @@
       <Action>
         <Name>ReadDeviceInfo</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -17296,6 +18679,31 @@
         <BitSize>32</BitSize>
         <BitOffs>160</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -17482,7 +18890,7 @@
       </Relations>
     </DataType>
     <DataType>
-      <Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+      <Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
       <BitSize>32</BitSize>
       <SubItem>
         <Name>Operational</Name>
@@ -17593,6 +19001,12 @@
         <BitOffs>17</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>IsDriveLimitActive</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>18</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>ContinuousMotion</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
         <BitSize>1</BitSize>
@@ -17679,6 +19093,11 @@
       <Format Name="IEC">
         <Printf>16#%08X</Printf>
       </Format>
+      <Relations>
+        <Relation Priority="100">
+          <Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
+        </Relation>
+      </Relations>
     </DataType>
     <DataType>
       <Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
@@ -17874,11 +19293,11 @@
       </ArrayInfo>
     </DataType>
     <DataType>
-      <Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+      <Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
       <BitSize>2048</BitSize>
       <SubItem>
         <Name>StateDWord</Name>
-        <Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+        <Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
         <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -18127,6 +19546,18 @@ External Setpoint Generation:
         <BitOffs>1600</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>AbsPhasingPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TorqueOffset</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1728</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>ActPosWithoutPosCorrection</Name>
         <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
         <BitSize>64</BitSize>
@@ -18172,6 +19603,9 @@ External Setpoint Generation:
         <Relation Priority="100">
           <Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
         </Relation>
+        <Relation Priority="100">
+          <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"/>
+        </Relation>
       </Relations>
     </DataType>
     <DataType>
@@ -18200,6 +19634,9 @@ External Setpoint Generation:
       <Name Namespace="Tc2_MC2">MC_AxisStates</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> 	PLCopen axis states
+	The axis states are defined in the PLCopen state diagram
+</Comment>
       <EnumInfo>
         <Text>MC_AXISSTATE_UNDEFINED</Text>
         <Enum>0</Enum>
@@ -19169,6 +20606,7 @@ External Setpoint Generation:
       <Name Namespace="Tc2_MC2">_E_PhasingState</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Phasing internal probe states </Comment>
       <EnumInfo>
         <Text>PhasingInactive</Text>
         <Enum>0</Enum>
@@ -19181,6 +20619,11 @@ External Setpoint Generation:
         <Text>PhasingAborted</Text>
         <Enum>2</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_InternalAxisRefData</Name>
@@ -19257,7 +20700,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>NcToPlc</Name>
-        <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</Type>
+        <Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</Type>
         <BitSize>2048</BitSize>
         <BitOffs>1088</BitOffs>
         <Properties>
@@ -19336,6 +20779,31 @@ External Setpoint Generation:
       <Action>
         <Name>ReadStatus</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -19365,6 +20833,14 @@ External Setpoint Generation:
         <Enum>2</Enum>
         <Comment> Enable before motion, disable after motion</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Name>
@@ -19385,6 +20861,14 @@ External Setpoint Generation:
         <Enum>2</Enum>
         <Comment> Do not change the brake state in FB_MotionStage</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Name>
@@ -19420,6 +20904,14 @@ External Setpoint Generation:
         <Enum>-1</Enum>
         <Comment> Do not home, ever</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_AxisParameterSet</Name>
@@ -21042,6 +22534,11 @@ External Setpoint Generation:
         <Text>STATE_MOTIONCOMMANDSLOCKED</Text>
         <Enum>104</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_ST_FunctionBlockResults</Name>
@@ -21212,6 +22709,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -21450,6 +22972,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -21610,6 +23157,11 @@ External Setpoint Generation:
         <Enum>12290</Enum>
         <Comment> 20190108 Fap - Start torque control relative NOT IMPLEMENTED </Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_TorqueControlOptions</Name>
@@ -22024,6 +23576,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -22698,6 +24275,31 @@ External Setpoint Generation:
       <Action>
         <Name>ActNcCycleCounter</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -22885,6 +24487,31 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>8576</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -23165,6 +24792,31 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>8704</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -23439,6 +25091,31 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>8768</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -23660,6 +25337,31 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>8768</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -24005,6 +25707,31 @@ External Setpoint Generation:
       <Action>
         <Name>ActCheckJogEnd</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -24253,6 +25980,31 @@ External Setpoint Generation:
       <Action>
         <Name>MC_MoveModuloCall</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -24554,6 +26306,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -24717,6 +26494,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -24961,6 +26763,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -25327,6 +27154,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -25461,6 +27313,31 @@ External Setpoint Generation:
         <BitSize>1216</BitSize>
         <BitOffs>288</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -25592,6 +27469,31 @@ External Setpoint Generation:
         <BitSize>1216</BitSize>
         <BitOffs>320</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -25752,6 +27654,31 @@ External Setpoint Generation:
         <BitSize>1536</BitSize>
         <BitOffs>1920</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26001,6 +27928,31 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>15648</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26149,6 +28101,31 @@ External Setpoint Generation:
         <BitSize>7168</BitSize>
         <BitOffs>256</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26280,6 +28257,31 @@ External Setpoint Generation:
         <BitSize>1248</BitSize>
         <BitOffs>288</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26440,6 +28442,31 @@ External Setpoint Generation:
         <BitSize>1536</BitSize>
         <BitOffs>1728</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26606,6 +28633,31 @@ External Setpoint Generation:
         <BitSize>1504</BitSize>
         <BitOffs>1760</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26737,6 +28789,31 @@ External Setpoint Generation:
         <BitSize>1248</BitSize>
         <BitOffs>320</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26891,6 +28968,31 @@ External Setpoint Generation:
         <BitSize>1600</BitSize>
         <BitOffs>1920</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27139,6 +29241,31 @@ External Setpoint Generation:
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27329,6 +29456,31 @@ External Setpoint Generation:
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27644,6 +29796,31 @@ External Setpoint Generation:
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27999,6 +30176,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28163,6 +30365,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28705,6 +30932,31 @@ External Setpoint Generation:
         <BitSize>768</BitSize>
         <BitOffs>162688</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28960,6 +31212,31 @@ External Setpoint Generation:
           <Value>99999999</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29091,6 +31368,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29155,6 +31457,31 @@ External Setpoint Generation:
         <BitSize>256</BitSize>
         <BitOffs>82848</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29177,6 +31504,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29199,6 +31551,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29334,6 +31711,31 @@ External Setpoint Generation:
       <Action>
         <Name>ActGetSizeOfParameterSet</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29419,6 +31821,31 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>2048</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29585,6 +32012,31 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>299296</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29728,6 +32180,31 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29819,6 +32296,11 @@ External Setpoint Generation:
         <Enum>18</Enum>
         <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
@@ -30108,6 +32590,31 @@ External Setpoint Generation:
       <Action>
         <Name>WriteGearRatio</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30244,6 +32751,31 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>9376</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30582,6 +33114,31 @@ External Setpoint Generation:
         <BitSize>9472</BitSize>
         <BitOffs>10944</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30845,6 +33402,31 @@ External Setpoint Generation:
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30925,6 +33507,31 @@ External Setpoint Generation:
         <BitSize>288</BitSize>
         <BitOffs>128192</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31189,6 +33796,31 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>768</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31379,6 +34011,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31617,6 +34274,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31711,11 +34393,38 @@ Use this thing to have a simple indexer with rollover.
       </Action>
       <Method>
         <Name>DecVal</Name>
+        <Comment>Decrement the counter and return new value</Comment>
         <ReturnType>INT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IncVal</Name>
+        <Comment>Increment the counter and return new value</Comment>
         <ReturnType>INT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
@@ -31794,6 +34503,14 @@ Use this thing to have a simple indexer with rollover.
         <Text>ABORT</Text>
         <Enum>2</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_MotionRequest</Name>
@@ -32105,6 +34822,31 @@ Use this thing to have a simple indexer with rollover.
           <Value>9</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33369,6 +36111,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>M_Init</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33659,6 +36426,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>M_Init</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33693,6 +36485,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33747,6 +36564,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33916,6 +36758,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>M_Init</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34252,6 +37119,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>ACT_Controller</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34325,7 +37217,7 @@ Use this thing to have a simple indexer with rollover.
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_optics">FB_PitchControl</Name>
-      <BitSize>365504</BitSize>
+      <BitSize>366848</BitSize>
       <SubItem>
         <Name>Pitch</Name>
         <Type Namespace="lcls_twincat_optics" ReferenceTo="true">HOMS_PitchMechanism</Type>
@@ -34414,9 +37306,9 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>POUName</Name>
-        <Type>STRING(80)</Type>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
         <Comment> Name of the POU for logging/error reporting</Comment>
-        <BitSize>648</BitSize>
+        <BitSize>2048</BitSize>
         <BitOffs>56960</BitOffs>
         <Properties>
           <Property>
@@ -34432,59 +37324,59 @@ Use this thing to have a simple indexer with rollover.
         <Type>LREAL</Type>
         <Comment> Actual Position of piezo mechanism</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>57664</BitOffs>
+        <BitOffs>59008</BitOffs>
       </SubItem>
       <SubItem>
         <Name>lrPrevStepperPos</Name>
         <Type>LREAL</Type>
         <Comment> Previous successfully achieved stepper position</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>57728</BitOffs>
+        <BitOffs>59072</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftLimitSwitch</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>57792</BitOffs>
+        <BitOffs>59136</BitOffs>
       </SubItem>
       <SubItem>
         <Name>lrOriginalPosRequest</Name>
         <Type>LREAL</Type>
         <Comment> Used for logging</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>57856</BitOffs>
+        <BitOffs>59200</BitOffs>
       </SubItem>
       <SubItem>
         <Name>lrLastSetpoint</Name>
         <Type>LREAL</Type>
         <Comment> Previous successfully achieved setpoint</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>57920</BitOffs>
+        <BitOffs>59264</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMotionRequest</Name>
         <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
         <BitSize>1600</BitSize>
-        <BitOffs>57984</BitOffs>
+        <BitOffs>59328</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMotionStage</Name>
         <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
         <BitSize>299392</BitSize>
-        <BitOffs>59584</BitOffs>
+        <BitOffs>60928</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bLimitHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>358976</BitOffs>
+        <BitOffs>360320</BitOffs>
       </SubItem>
       <SubItem>
         <Name>tonStepperHold</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <Comment> Timer to hold stepper position while the system relaxes</Comment>
         <BitSize>224</BitSize>
-        <BitOffs>359008</BitOffs>
+        <BitOffs>360352</BitOffs>
         <Default>
           <SubItem>
             <Name>.PT</Name>
@@ -34497,7 +37389,7 @@ Use this thing to have a simple indexer with rollover.
         <Type>REAL</Type>
         <Comment> Units = urad</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>359232</BitOffs>
+        <BitOffs>360576</BitOffs>
         <Default>
           <Value>5</Value>
         </Default>
@@ -34506,20 +37398,20 @@ Use this thing to have a simple indexer with rollover.
         <Name>bResetStepper</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>359264</BitOffs>
+        <BitOffs>360608</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecuteStepper</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>359272</BitOffs>
+        <BitOffs>360616</BitOffs>
       </SubItem>
       <SubItem>
         <Name>enumMotionRequest</Name>
         <Type Namespace="lcls_twincat_motion">ENUM_MotionRequest</Type>
         <Comment> Wait for move to complete before taking another request</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>359280</BitOffs>
+        <BitOffs>360624</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -34529,7 +37421,7 @@ Use this thing to have a simple indexer with rollover.
         <Type Namespace="Tc2_Standard">TON</Type>
         <Comment> Piezo</Comment>
         <BitSize>224</BitSize>
-        <BitOffs>359296</BitOffs>
+        <BitOffs>360640</BitOffs>
         <Default>
           <SubItem>
             <Name>.PT</Name>
@@ -34541,20 +37433,20 @@ Use this thing to have a simple indexer with rollover.
         <Name>fbPiezoControl</Name>
         <Type Namespace="lcls_twincat_optics">FB_PiezoControl</Type>
         <BitSize>5824</BitSize>
-        <BitOffs>359552</BitOffs>
+        <BitOffs>360896</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtPiezoMoveDone</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>365376</BitOffs>
+        <BitOffs>366720</BitOffs>
       </SubItem>
       <SubItem>
         <Name>PC_State</Name>
         <Type Namespace="lcls_twincat_optics">E_PitchControl</Type>
         <Comment> State Machine</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>365440</BitOffs>
+        <BitOffs>366784</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -34563,11 +37455,36 @@ Use this thing to have a simple indexer with rollover.
         <Name>bCoarse50PiezoMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>365456</BitOffs>
+        <BitOffs>366800</BitOffs>
       </SubItem>
       <Action>
         <Name>ACT_ResetSetpoint</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34614,6 +37531,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -35326,6 +38268,11 @@ Use this thing to have a simple indexer with rollover.
         <Enum>4</Enum>
         <Comment> any parameter with size &gt; LREAL; used for LINT or ULINT as well</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_ST_ParaStruct</Name>
@@ -35630,6 +38577,31 @@ Use this thing to have a simple indexer with rollover.
           <Value>2</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -35816,6 +38788,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -35824,7 +38821,7 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{944726B1-A958-40A6-B97D-51A67664C20E}" TcBaseType="true" CName="TcEventConfirmationState">TcEventConfirmationState</Name>
+      <Name GUID="{944726B1-A958-40A6-B97D-51A67664C20E}" TcBaseType="true" CName="TcEventConfirmationState*">TcEventConfirmationState</Name>
       <BitSize>16</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
       <EnumInfo>
@@ -35983,7 +38980,7 @@ Use this thing to have a simple indexer with rollover.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>82218428</GetCodeOffs>
+        <GetCodeOffs>82093928</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="45">__getnTimestamp</Name>
@@ -36007,6 +39004,31 @@ Use this thing to have a simple indexer with rollover.
             <Value>18071995-0000-0000-0000-000000000046</Value>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>Release</Name>
@@ -36046,8 +39068,8 @@ Use this thing to have a simple indexer with rollover.
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
-        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
+        <Name>__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>ipEvent</Name>
@@ -36164,121 +39186,6 @@ Use this thing to have a simple indexer with rollover.
       </Method>
     </DataType>
     <DataType>
-      <Name GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" CName="ITcEventFilterConfig*">ITcEventFilterConfig</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>AddEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>eventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}" ReferenceTo="true" Const="1">GUID</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>severity</Name>
-          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RemoveEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>eventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}" ReferenceTo="true" Const="1">GUID</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddSourceInfo</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}" Const="1">ITcSourceInfo</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>severity</Name>
-          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RemoveSourceInfo</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}" Const="1">ITcSourceInfo</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}" CName="ITcMessageListener*">ITcMessageListener</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>OnMessageSent</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}" CName="ITcAlarmListener*">ITcAlarmListener</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>OnAlarmRaised</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>OnAlarmCleared</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>OnAlarmConfirmed</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>OnAlarmDisposed</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.Tc3_EventLogger">FB_ListenerWrapper</Name>
       <BitSize>3840</BitSize>
       <Implements GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Implements>
@@ -36303,6 +39210,21 @@ Use this thing to have a simple indexer with rollover.
             <Value>4</Value>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>OnAlarmRaised</Name>
@@ -36385,6 +39307,16 @@ Use this thing to have a simple indexer with rollover.
             <Value>4</Value>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>TcQueryInterface</Name>
@@ -36622,6 +39554,21 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>64</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>OnAlarmRaised</Name>
         <Parameter>
           <Name>fbEvent</Name>
@@ -36644,6 +39591,16 @@ Use this thing to have a simple indexer with rollover.
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -36903,9 +39860,331 @@ Use this thing to have a simple indexer with rollover.
       </Hides>
     </DataType>
     <DataType>
+      <Name GUID="{D12E7FB5-17AA-426E-9B82-E253AE65DC47}" TcBaseType="true" CName="TcEventType*">TcEventType</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>Message</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Alarm</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}" TcBaseType="true" CName="TcComparisonOperator*">TcComparisonOperator</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>EqualTo</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NotEqualTo</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>LessThan</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>GreaterThan</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>LessThanOrEqualTo</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>GreaterThanOrEqualTo</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{B69885BA-DA24-48A8-A6FA-6099F5D3601B}" TcBaseType="true" CName="TcEventTimeStampType*">TcEventTimeStampType</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>Raised</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Confirmed</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Cleared</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{27A7EA8A-FB15-4687-A4D8-6989F4A71351}" TcBaseType="true" CName="TcStringComparisonOperator*">TcStringComparisonOperator</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>EqualTo</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NotEqualTo</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Like</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IsNull</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IsNotNull</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{CA520B34-C0F8-4AD3-9514-6B6626A12566}" TcBaseType="true" CName="TcLogicalOperator*">TcLogicalOperator</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>And</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Or</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name GUID="{7404CD52-3776-4B1A-9525-B7C1D691DFC4}" TcBaseType="true" CName="ITcEventFilter*">ITcEventFilter</Name>
       <BitSize X64="64">32</BitSize>
       <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AddEventTypeExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eType</Name>
+          <Type GUID="{D12E7FB5-17AA-426E-9B82-E253AE65DC47}">TcEventType</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}">TcComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventClassExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}" ReferenceTo="true" Const="1">GUID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}">TcComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventIdExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}">TcComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddSeverityExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>severity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}">TcComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddTimeStampExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eType</Name>
+          <Type GUID="{B69885BA-DA24-48A8-A6FA-6099F5D3601B}">TcEventTimeStampType</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>timeStamp</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}">TcComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddSourceGuidExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sourceGuid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}" ReferenceTo="true" Const="1">GUID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}">TcComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddSourceIdExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sourceId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{4CF44F1F-8924-4AAC-8432-0F7294012F1B}">TcComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddSourceNameExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sourceName</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000001A}">PCCH</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{27A7EA8A-FB15-4687-A4D8-6989F4A71351}">TcStringComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddJsonAttributeExpression</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>path</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000001A}">PCCH</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000001A}">PCCH</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>op</Name>
+          <Type GUID="{27A7EA8A-FB15-4687-A4D8-6989F4A71351}">TcStringComparisonOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLogicalOperator</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eType</Name>
+          <Type GUID="{CA520B34-C0F8-4AD3-9514-6B6626A12566}">TcLogicalOperator</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNotOperator</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>CreateExpressionGroup</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pipGroup</Name>
+          <Type GUID="{7404CD52-3776-4B1A-9525-B7C1D691DFC4}" PointerTo="1">ITcEventFilter</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddExpressionGroup</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipGroup</Name>
+          <Type GUID="{7404CD52-3776-4B1A-9525-B7C1D691DFC4}">ITcEventFilter</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
     </DataType>
     <DataType>
       <Name GUID="{A36B5464-1369-43FB-8C93-7914F7BE824F}" TcBaseType="true" CName="ITcEventListener*">ITcEventListener</Name>
@@ -37662,8 +40941,8 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc">__getipData</Name>
-        <ReturnType GUID="{91542D18-3837-4A8C-B5EF-F1A9F135A613}" RpcDirection="out">ITcRemoteEventLogger</ReturnType>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{91542D18-3837-4A8C-B5EF-F1A9F135A613}">ITcRemoteEventLogger</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -37682,31 +40961,31 @@ Use this thing to have a simple indexer with rollover.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82217984</GetCodeOffs>
+        <GetCodeOffs>82093480</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82218028</GetCodeOffs>
+        <GetCodeOffs>82093524</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82217992</GetCodeOffs>
+        <GetCodeOffs>82093488</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82218016</GetCodeOffs>
+        <GetCodeOffs>82093512</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82218036</GetCodeOffs>
+        <GetCodeOffs>82093532</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -37803,6 +41082,21 @@ Use this thing to have a simple indexer with rollover.
         </Properties>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -37815,6 +41109,16 @@ Use this thing to have a simple indexer with rollover.
           <Name>nResult</Name>
           <Comment> buffer size in bytes</Comment>
           <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -37993,6 +41297,8 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <Method>
         <Name>GetJsonFromSymbol</Name>
+        <Comment> | generates a JSON string from a given symbol (via address/size).
+ | Method returns TRUE if succeeded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -38045,6 +41351,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
+        <Comment>| Copies the full DOM document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -38107,7 +41414,23 @@ Use this thing to have a simple indexer with rollover.
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>CopySymbolNameByAddress</Name>
+        <Comment> generates name of symbol defined by address/size and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -38158,7 +41481,18 @@ Use this thing to have a simple indexer with rollover.
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetSizeJsonStringFromSymbol</Name>
+        <Comment> Returns size in bytes of the full DOM document (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -38209,6 +41543,8 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -38259,6 +41595,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>AddJsonKeyPropertiesFromSymbol</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -38326,6 +41663,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>GetDatatypeNameByAddress</Name>
+        <Comment> generates data type name from given symbol defined by address/size</Comment>
         <ReturnType>STRING(80)</ReturnType>
         <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
@@ -38364,6 +41702,8 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>SetSymbolFromJson</Name>
+        <Comment> | parse a json string and set values of a given symbol (via address/size).
+ | Method returns TRUE if succeeded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -38416,6 +41756,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>GetSizeJsonStringFromSymbolProperties</Name>
+        <Comment> Returns size in bytes of the full DOM document (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -38466,6 +41807,8 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>GetJsonStringFromSymbol</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbol() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -38516,6 +41859,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbol</Name>
+        <Comment>| Copies the full DOM document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -38579,6 +41923,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>GetSymbolNameByAddress</Name>
+        <Comment> generates name of symbol defined by address/size</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -38612,6 +41957,9 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>AddJsonValueFromSymbol</Name>
+        <Comment> | generates a JSON string from a given symbol (via address/size) 
+ | and adds it to a JSON document via the given SAX Writer.
+ | Method returns TRUE if succeeded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -38668,6 +42016,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>AddJsonKeyValueFromSymbol</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -38754,6 +42103,7 @@ Use this thing to have a simple indexer with rollover.
       <Name Namespace="LCLS_General.Tc2_TcpIp">E_SocketConnectionlessState</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Connectionless socket state  </Comment>
       <EnumInfo>
         <Text>eSOCKET_CLOSED</Text>
         <Enum>0</Enum>
@@ -38932,6 +42282,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -39129,7 +42504,7 @@ Use this thing to have a simple indexer with rollover.
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__CONFIGURE__BSUBSCRIBED</Name>
+        <Name>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>864480</BitOffs>
@@ -39138,23 +42513,38 @@ Use this thing to have a simple indexer with rollover.
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__PUBLISHEVENTS__FBJSON</Name>
+        <Name>__FB_LISTENER__PUBLISHEVENTS__FBJSON</Name>
         <Type Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</Type>
         <BitSize>256</BitSize>
         <BitOffs>864512</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__PUBLISHEVENTS__FBJSONDATATYPE</Name>
+        <Name>__FB_LISTENER__PUBLISHEVENTS__FBJSONDATATYPE</Name>
         <Type Namespace="LCLS_General.Tc3_JsonXml">FB_JsonReadWriteDatatype</Type>
         <BitSize>96</BitSize>
         <BitOffs>864768</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__PUBLISHEVENTS__SJSONDOC</Name>
+        <Name>__FB_LISTENER__PUBLISHEVENTS__SJSONDOC</Name>
         <Type>STRING(10000)</Type>
         <BitSize>80008</BitSize>
         <BitOffs>864864</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Method>
         <Name>OnAlarmRaised</Name>
         <Parameter>
@@ -39172,8 +42562,8 @@ Use this thing to have a simple indexer with rollover.
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Local>
           <Name>LogToVisualStudio</Name>
@@ -39195,6 +42585,16 @@ Use this thing to have a simple indexer with rollover.
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -39252,7 +42652,7 @@ Use this thing to have a simple indexer with rollover.
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__PUBLISHEVENTS__FBJSON</Value>
+              <Value>__FB_LISTENER__PUBLISHEVENTS__FBJSON</Value>
             </Property>
           </Properties>
         </Local>
@@ -39263,7 +42663,7 @@ Use this thing to have a simple indexer with rollover.
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__PUBLISHEVENTS__FBJSONDATATYPE</Value>
+              <Value>__FB_LISTENER__PUBLISHEVENTS__FBJSONDATATYPE</Value>
             </Property>
           </Properties>
         </Local>
@@ -39274,7 +42674,7 @@ Use this thing to have a simple indexer with rollover.
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__PUBLISHEVENTS__SJSONDOC</Value>
+              <Value>__FB_LISTENER__PUBLISHEVENTS__SJSONDOC</Value>
             </Property>
           </Properties>
         </Local>
@@ -39311,6 +42711,9 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>Configure</Name>
+        <Comment>
+    Configure an event class + severity
+</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -39335,16 +42738,16 @@ Use this thing to have a simple indexer with rollover.
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__CONFIGURE__BSUBSCRIBED</Value>
+              <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="16">__setLogToVisualStudio</Name>
+        <Name>__setLogToVisualStudio</Name>
         <Parameter>
           <Name>LogToVisualStudio</Name>
-          <Type RpcDirection="in">BOOL</Type>
+          <Type>BOOL</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -39517,6 +42920,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -39620,6 +43048,31 @@ Use this thing to have a simple indexer with rollover.
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -39657,6 +43110,7 @@ Use this thing to have a simple indexer with rollover.
       <Name Namespace="Tc2_Utilities">E_MIB_IF_Type</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Management Information Base interface type </Comment>
       <EnumInfo>
         <Text>MIB_IF_TYPE_UNKNOWN</Text>
         <Enum>0</Enum>
@@ -40083,6 +43537,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -40553,6 +44032,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -40673,6 +44177,31 @@ Use this thing to have a simple indexer with rollover.
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -40764,6 +44293,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -41052,6 +44606,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>CircuitBreaker</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -41294,6 +44873,31 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>8</BitSize>
         <BitOffs>2496</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -41408,6 +45012,31 @@ Use this thing to have a simple indexer with rollover.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -41457,6 +45086,31 @@ Use this thing to have a simple indexer with rollover.
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -41503,6 +45157,31 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>3136</BitSize>
         <BitOffs>8704</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -41785,6 +45464,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>StateHandler</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -41798,6 +45502,7 @@ Use this thing to have a simple indexer with rollover.
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
         <Name>CheckRequest</Name>
+        <Comment>Verify with this higher authority that the request is being included</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -41808,6 +45513,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>RemoveRequest</Name>
+        <Comment>Remove the request from this higher authority</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -41819,6 +45525,7 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>RequestBP</Name>
+        <Comment> Request a BP from this higher authority</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -41840,8 +45547,8 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getnLowerAuthorityID</Name>
-        <ReturnType RpcDirection="out">DWORD</ReturnType>
+        <Name>__getnLowerAuthorityID</Name>
+        <ReturnType>DWORD</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -41851,6 +45558,10 @@ Use this thing to have a simple indexer with rollover.
       </Method>
       <Method>
         <Name>ElevateRequest</Name>
+        <Comment> &lt;Arbiter Internal&gt;
+ Elevates the arbitrated BP set to something above.
+ Could be another arbiter, or a BP requester/ IO, 
+ or an FB that locks in a specific portion of the BP set.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -42333,6 +46044,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>A_Lookup</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -42574,6 +46310,31 @@ Use this thing to have a simple indexer with rollover.
       <Action>
         <Name>A_Lookup</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -42794,7 +46555,7 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__GETARBITRATEDBP__XFIRSTPASS</Name>
+        <Name>__FB_ARBITER__GETARBITRATEDBP__XFIRSTPASS</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>228456</BitOffs>
@@ -42803,38 +46564,54 @@ These features efficiently address the addition, removal, and verification of be
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__GETARBITRATEDBP__FBGETCURTASKIDX</Name>
+        <Name>__FB_ARBITER__GETARBITRATEDBP__FBGETCURTASKIDX</Name>
         <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
         <BitSize>128</BitSize>
         <BitOffs>228480</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__GETARBITRATEDBP__LASTCYCLECOUNT</Name>
+        <Name>__FB_ARBITER__GETARBITRATEDBP__LASTCYCLECOUNT</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
         <BitOffs>228608</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__GETARBITRATEDBP__FBLOGMESSAGE</Name>
+        <Name>__FB_ARBITER__GETARBITRATEDBP__FBLOGMESSAGE</Name>
         <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>228672</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__ADDREQUEST__FBLOG</Name>
+        <Name>__FB_ARBITER__ADDREQUEST__FBLOG</Name>
         <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>310656</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__REMOVEREQUEST__FBLOG</Name>
+        <Name>__FB_ARBITER__REMOVEREQUEST__FBLOG</Name>
         <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>392640</BitOffs>
       </SubItem>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>nEntryCount</Name>
@@ -42849,6 +46626,14 @@ These features efficiently address the addition, removal, and verification of be
       </Method>
       <Method>
         <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -42863,7 +46648,21 @@ These features efficiently address the addition, removal, and verification of be
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>ElevateRequest</Name>
+        <Comment> &lt;Arbiter Internal&gt;
+ Elevates the arbitrated BP set to something above.
+ Could be another arbiter, or a BP requester/ IO, 
+ or an FB that locks in a specific portion of the BP set.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -42874,6 +46673,7 @@ These features efficiently address the addition, removal, and verification of be
       </Method>
       <Method>
         <Name>GetArbitratedBP</Name>
+        <Comment> Executes Arbitration between all requested beam parameter sets</Comment>
         <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
         <ReturnBitSize>1760</ReturnBitSize>
         <Local>
@@ -42899,7 +46699,7 @@ These features efficiently address the addition, removal, and verification of be
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__XFIRSTPASS</Value>
+              <Value>__FB_ARBITER__GETARBITRATEDBP__XFIRSTPASS</Value>
             </Property>
           </Properties>
         </Local>
@@ -42910,7 +46710,7 @@ These features efficiently address the addition, removal, and verification of be
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__FBGETCURTASKIDX</Value>
+              <Value>__FB_ARBITER__GETARBITRATEDBP__FBGETCURTASKIDX</Value>
             </Property>
           </Properties>
         </Local>
@@ -42921,7 +46721,7 @@ These features efficiently address the addition, removal, and verification of be
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__LASTCYCLECOUNT</Value>
+              <Value>__FB_ARBITER__GETARBITRATEDBP__LASTCYCLECOUNT</Value>
             </Property>
           </Properties>
         </Local>
@@ -42932,13 +46732,15 @@ These features efficiently address the addition, removal, and verification of be
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__GETARBITRATEDBP__FBLOGMESSAGE</Value>
+              <Value>__FB_ARBITER__GETARBITRATEDBP__FBLOGMESSAGE</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>ArbitrateBP</Name>
+        <Comment> Kernel of the arbiter
+ Logic for determining which beam parameter is the most conservative across all request sets.</Comment>
         <ReturnType Namespace="PMPS">ST_BP_ArbInternal</ReturnType>
         <ReturnBitSize>2464</ReturnBitSize>
         <Parameter>
@@ -42968,8 +46770,8 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__getnLowerAuthorityID</Name>
-        <ReturnType RpcDirection="out">DWORD</ReturnType>
+        <Name>__getnLowerAuthorityID</Name>
+        <ReturnType>DWORD</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>nLowerAuthorityID</Name>
@@ -42984,6 +46786,8 @@ These features efficiently address the addition, removal, and verification of be
       </Method>
       <Method>
         <Name>AddRequest</Name>
+        <Comment> Adds a request to the arbiter pool.
+ Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -43016,13 +46820,14 @@ These features efficiently address the addition, removal, and verification of be
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__ADDREQUEST__FBLOG</Value>
+              <Value>__FB_ARBITER__ADDREQUEST__FBLOG</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -43037,7 +46842,7 @@ These features efficiently address the addition, removal, and verification of be
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REMOVEREQUEST__FBLOG</Value>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
             </Property>
           </Properties>
         </Local>
@@ -43049,6 +46854,9 @@ These features efficiently address the addition, removal, and verification of be
       </Method>
       <Method>
         <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -43405,6 +47213,31 @@ These features efficiently address the addition, removal, and verification of be
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -43541,6 +47374,7 @@ These features efficiently address the addition, removal, and verification of be
       <Name Namespace="Tc2_Utilities">E_TimeZoneID</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Time zone identifier </Comment>
       <EnumInfo>
         <Text>eTimeZoneID_Invalid</Text>
         <Enum>-1</Enum>
@@ -43682,6 +47516,31 @@ These features efficiently address the addition, removal, and verification of be
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -43879,6 +47738,31 @@ These features efficiently address the addition, removal, and verification of be
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -44083,6 +47967,31 @@ These features efficiently address the addition, removal, and verification of be
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -44292,6 +48201,31 @@ These features efficiently address the addition, removal, and verification of be
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -44524,6 +48458,31 @@ These features efficiently address the addition, removal, and verification of be
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -44805,6 +48764,31 @@ These features efficiently address the addition, removal, and verification of be
       <Action>
         <Name>A_Reset</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -44901,6 +48885,31 @@ These features efficiently address the addition, removal, and verification of be
       <Action>
         <Name>A_Reset</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -45200,7 +49209,7 @@ These features efficiently address the addition, removal, and verification of be
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__EXECUTELOGGING__HELLOTIMER</Name>
+        <Name>__FB_HARDWAREFFOUTPUT__EXECUTELOGGING__HELLOTIMER</Name>
         <Type Namespace="Tc2_Standard">TOF</Type>
         <BitSize>224</BitSize>
         <BitOffs>495040</BitOffs>
@@ -45278,7 +49287,7 @@ These features efficiently address the addition, removal, and verification of be
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__EXECUTELOGGING__HELLOTIMER</Value>
+              <Value>__FB_HARDWAREFFOUTPUT__EXECUTELOGGING__HELLOTIMER</Value>
             </Property>
           </Properties>
         </Local>
@@ -45287,6 +49296,31 @@ These features efficiently address the addition, removal, and verification of be
             <Name>no_check</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>Register</Name>
@@ -45821,6 +49855,21 @@ These features efficiently address the addition, removal, and verification of be
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetStateCode</Name>
         <ReturnType>INT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
@@ -45828,6 +49877,16 @@ These features efficiently address the addition, removal, and verification of be
           <Name>nState</Name>
           <Type>INT</Type>
           <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -46099,6 +50158,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>2048</BitSize>
         <BitOffs>23040</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -46603,6 +50687,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>DeauthorizeTransition</Name>
       </Action>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>LogActions</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -46748,6 +50857,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <Action>
         <Name>ClearAsserts</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -46917,6 +51051,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>64</BitSize>
         <BitOffs>27744</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -47012,6 +51171,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           </SubItem>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -47189,6 +51373,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <Action>
         <Name>PMPSHandler</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -47212,6 +51421,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Text>W</Text>
         <Enum>2</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified only</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name>FB_Coating_States</Name>
@@ -47285,6 +51502,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>8</BitSize>
         <BitOffs>472720</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -47296,6 +51538,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <Name Namespace="lcls_twincat_motion">ENUM_EpicsInOut</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Example EPICS states enum for use in FB_PositionStateManager
+ Remove strict attribute for easier handling</Comment>
       <EnumInfo>
         <Text>UNKNOWN</Text>
         <Enum>0</Enum>
@@ -47310,6 +51554,11 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Text>IN</Text>
         <Enum>2</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStateInOut</Name>
@@ -47387,6 +51636,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>8</BitSize>
         <BitOffs>237264</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -47466,6 +51740,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>8</BitSize>
         <BitOffs>237264</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -47686,6 +51985,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Value>1</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -47801,6 +52125,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Parameter>
           <Name>nReqID</Name>
           <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -48249,7 +52598,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitOffs>56704</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__CHECKREQUEST__XFIRSTTIME</Name>
+        <Name>__FB_SUBSYSTOARBITER_IO__CHECKREQUEST__XFIRSTTIME</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>138688</BitOffs>
@@ -48258,7 +52607,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__CHECKREQUEST__NID</Name>
+        <Name>__FB_SUBSYSTOARBITER_IO__CHECKREQUEST__NID</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
         <BitOffs>138720</BitOffs>
@@ -48279,7 +52628,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__CHECKREQUEST__XFIRSTTIME</Value>
+              <Value>__FB_SUBSYSTOARBITER_IO__CHECKREQUEST__XFIRSTTIME</Value>
             </Property>
           </Properties>
         </Local>
@@ -48290,10 +52639,35 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__CHECKREQUEST__NID</Value>
+              <Value>__FB_SUBSYSTOARBITER_IO__CHECKREQUEST__NID</Value>
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -48461,175 +52835,280 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Hides>
     </DataType>
     <DataType>
-      <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
+      <Name GUID="{BB2A9999-102E-421A-8D3D-B0660E07B1FE}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
         <Name Id="1">InternalError</Name>
-        <DisplayName TxtId="">InternalError</DisplayName>
+        <DisplayName TxtId="">Internal error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="2">NoRTime</Name>
-        <DisplayName TxtId="">NoRTime</DisplayName>
+        <DisplayName TxtId="">No real-time.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="3">AllocationLockedMemoryError</Name>
-        <DisplayName TxtId="">AllocationLockedMemoryError</DisplayName>
+        <DisplayName TxtId="">Allocation locked – memory error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4">InsertMailboxError</Name>
-        <DisplayName TxtId="">InsertMailboxError</DisplayName>
+        <DisplayName TxtId="">Mailbox full – the ADS message could not be sent. Reducing the number of ADS messages per cycle will help.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="5">WrongReceiveHMSG</Name>
-        <DisplayName TxtId="">WrongReceiveHMSG</DisplayName>
+        <DisplayName TxtId="">Wrong HMSG.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="6">TargetPortNotFound</Name>
-        <DisplayName TxtId="">TargetPortNotFound (possible cause: ADS server not started)</DisplayName>
+        <DisplayName TxtId="">Target port not found – ADS server is not started or is not reachable.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="7">TargetMachineNotFound</Name>
-        <DisplayName TxtId="">TargetMachineNotFound (possible cause: missing ADS route)</DisplayName>
+        <DisplayName TxtId="">Target computer not found – AMS route was not found. </DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="8">UnknownCommandID</Name>
-        <DisplayName TxtId="">UnknownCommandID</DisplayName>
+        <DisplayName TxtId="">Unknown command ID.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="9">BadTaskID</Name>
-        <DisplayName TxtId="">BadTaskID</DisplayName>
+        <DisplayName TxtId="">Invalid task ID.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="10">NoIO</Name>
-        <DisplayName TxtId="">NoIO</DisplayName>
+        <DisplayName TxtId="">No IO.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="11">UnknownAdsCommand</Name>
-        <DisplayName TxtId="">UnknownAdsCommand</DisplayName>
+        <DisplayName TxtId="">Unknown AMS command.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="12">Win32Error</Name>
-        <DisplayName TxtId="">Win32Error</DisplayName>
+        <DisplayName TxtId="">Win32 error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="13">PortNotConnected</Name>
-        <DisplayName TxtId="">PortNotConnected</DisplayName>
+        <DisplayName TxtId="">Port not connected.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="14">InvalidAdsLength</Name>
-        <DisplayName TxtId="">InvalidAdsLength</DisplayName>
+        <DisplayName TxtId="">Invalid AMS length.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="15">InvalidAdsNetID</Name>
-        <DisplayName TxtId="">InvalidAdsNetID</DisplayName>
+        <DisplayName TxtId="">Invalid AMS Net ID.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="16">LowInstallationLevel</Name>
-        <DisplayName TxtId="">LowInstallationLevel</DisplayName>
+        <DisplayName TxtId="">Low installation level – TwinCAT 2 license error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="17">NoDebugAvailable</Name>
-        <DisplayName TxtId="">NoDebugAvailable</DisplayName>
+        <DisplayName TxtId="">No debugging available.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="18">PortDisabled</Name>
-        <DisplayName TxtId="">PortDisabled</DisplayName>
+        <DisplayName TxtId="">Port disabled – TwinCAT system service not started.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="19">PortAlreadyConnected</Name>
-        <DisplayName TxtId="">PortAlreadyConnected</DisplayName>
+        <DisplayName TxtId="">Port already connected.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="20">AdsSyncWin32Error</Name>
-        <DisplayName TxtId="">AdsSyncWin32Error</DisplayName>
+        <DisplayName TxtId="">AMS Sync Win32 error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="21">AdsSyncTimeout</Name>
-        <DisplayName TxtId="">AdsSyncTimeout</DisplayName>
+        <DisplayName TxtId="">AMS Sync Timeout.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="22">AdsSyncAmsError</Name>
-        <DisplayName TxtId="">AdsSyncAmsError</DisplayName>
+        <DisplayName TxtId="">AMS Sync error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="23">AdsSyncNoIndexMap</Name>
-        <DisplayName TxtId="">AdsSyncNoIndexMap</DisplayName>
+        <DisplayName TxtId="">No index map for AMS Sync available.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="24">InvalidAdsPort</Name>
-        <DisplayName TxtId="">InvalidAdsPort</DisplayName>
+        <DisplayName TxtId="">Invalid AMS port.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="25">NoMemory</Name>
-        <DisplayName TxtId="">NoMemory</DisplayName>
+        <DisplayName TxtId="">No memory.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="26">TCPSendError</Name>
-        <DisplayName TxtId="">TCPSendError</DisplayName>
+        <DisplayName TxtId="">TCP send error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="27">HostUnreachable</Name>
-        <DisplayName TxtId="">HostUnreachable</DisplayName>
+        <DisplayName TxtId="">Host unreachable.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="28">InvalidAMSFragment</Name>
-        <DisplayName TxtId="">InvalidAMSFragment</DisplayName>
+        <DisplayName TxtId="">Invalid AMS fragment.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
+      <EventId>
+        <Name Id="29">AdsSecTLSSendError</Name>
+        <DisplayName TxtId="">TLS send error – secure ADS connection failed.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="30">AdsSecAccessDenied</Name>
+        <DisplayName TxtId="">Access denied – secure ADS access denied.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <Translations>
+        <Text TxtId="Internal error.">
+          <Text LcId="1031">Interner Fehler.</Text>
+        </Text>
+        <Text TxtId="No real-time.">
+          <Text LcId="1031">Keine Echtzeit.</Text>
+        </Text>
+        <Text TxtId="Allocation locked – memory error.">
+          <Text LcId="1031">Zuweisung gesperrt - Speicherfehler.</Text>
+        </Text>
+        <Text TxtId="Mailbox full – the ADS message could not be sent. Reducing the number of ADS messages per cycle will help.">
+          <Text LcId="1031">Postfach voll – Es konnte die ADS Nachricht nicht versendet werden. Reduzieren der Anzahl der ADS Nachrichten pro Zyklus bringt Abhilfe.</Text>
+        </Text>
+        <Text TxtId="Wrong HMSG.">
+          <Text LcId="1031">Falsches HMSG.</Text>
+        </Text>
+        <Text TxtId="Target port not found – ADS server is not started or is not reachable.">
+          <Text LcId="1031">Ziel-Port nicht gefunden – ADS Server ist nicht gestartet oder erreichbar.</Text>
+        </Text>
+        <Text TxtId="Unknown command ID.">
+          <Text LcId="1031">Unbekannte Befehl-ID.</Text>
+        </Text>
+        <Text TxtId="Invalid task ID.">
+          <Text LcId="1031">Ungültige Task-ID.</Text>
+        </Text>
+        <Text TxtId="No IO.">
+          <Text LcId="1031">Kein IO.</Text>
+        </Text>
+        <Text TxtId="Unknown AMS command.">
+          <Text LcId="1031">Unbekannter AMS-Befehl.</Text>
+        </Text>
+        <Text TxtId="Win32 error.">
+          <Text LcId="1031">Win32 Fehler.</Text>
+        </Text>
+        <Text TxtId="Port not connected.">
+          <Text LcId="1031">Port nicht verbunden.</Text>
+        </Text>
+        <Text TxtId="Invalid AMS length.">
+          <Text LcId="1031">Ungültige AMS-Länge.</Text>
+        </Text>
+        <Text TxtId="Invalid AMS Net ID.">
+          <Text LcId="1031">Ungültige AMS Net ID.</Text>
+        </Text>
+        <Text TxtId="Low installation level – TwinCAT 2 license error.">
+          <Text LcId="1031">Installations-Level ist zu niedrig – TwinCAT 2 Lizenzfehler.</Text>
+        </Text>
+        <Text TxtId="No debugging available.">
+          <Text LcId="1031">Kein Debugging verfügbar.</Text>
+        </Text>
+        <Text TxtId="Port disabled – TwinCAT system service not started.">
+          <Text LcId="1031">Port deaktiviert – TwinCAT System Service nicht gestartet.</Text>
+        </Text>
+        <Text TxtId="Port already connected.">
+          <Text LcId="1031">Port bereits verbunden.</Text>
+        </Text>
+        <Text TxtId="AMS Sync Win32 error.">
+          <Text LcId="1031">AMS Sync Win32 Fehler.</Text>
+        </Text>
+        <Text TxtId="AMS Sync Timeout.">
+          <Text LcId="1031">AMS Sync Timeout.</Text>
+        </Text>
+        <Text TxtId="AMS Sync error.">
+          <Text LcId="1031">AMS Sync Fehler.</Text>
+        </Text>
+        <Text TxtId="No index map for AMS Sync available.">
+          <Text LcId="1031">Keine Index-Map für AMS Sync vorhanden.</Text>
+        </Text>
+        <Text TxtId="Invalid AMS port.">
+          <Text LcId="1031">Ungültiger AMS-Port.</Text>
+        </Text>
+        <Text TxtId="No memory.">
+          <Text LcId="1031">Kein Speicher.</Text>
+        </Text>
+        <Text TxtId="TCP send error.">
+          <Text LcId="1031">TCP Sendefehler.</Text>
+        </Text>
+        <Text TxtId="Host unreachable.">
+          <Text LcId="1031">Host nicht erreichbar.</Text>
+        </Text>
+        <Text TxtId="Invalid AMS fragment.">
+          <Text LcId="1031">Ungültiges AMS Fragment.</Text>
+        </Text>
+        <Text TxtId="TLS send error – secure ADS connection failed.">
+          <Text LcId="1031">TLS Sendefehler – Secure ADS Verbindung fehlgeschlagen.</Text>
+        </Text>
+        <Text TxtId="Access denied – secure ADS access denied.">
+          <Text LcId="1031">Zugriff Verweigert – Secure ADS Zugriff verweigert.</Text>
+        </Text>
+      </Translations>
+      <Hides>
+        <Hide GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}"/>
+        <Hide GUID="{B2BBE2AF-D093-4B0F-BE44-FCF3140A3212}"/>
+        <Hide GUID="{EF57FA70-34C2-47F2-B661-D7FFBEC2C9A9}"/>
+        <Hide GUID="{EF9200FE-E527-4DE7-BF5A-C4237524B2D2}"/>
+      </Hides>
     </DataType>
     <DataType>
-      <Name GUID="{98BCB284-F932-4EA4-B58B-68A1F1C34192}" TcBaseType="true" CName="TcGeneralAdsEventClass">TcGeneralAdsEventClass</Name>
+      <Name GUID="{7D760066-D373-4A0C-B0F1-328B1620B0F0}" TcBaseType="true" CName="TcGeneralAdsEventClass">TcGeneralAdsEventClass</Name>
       <DisplayName TxtId="">TcGeneralAdsEventClass</DisplayName>
       <EventId>
         <Name Id="1792">GeneralDeviceError</Name>
-        <DisplayName TxtId="">General device error</DisplayName>
+        <DisplayName TxtId="">General device error.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1793">ServiceNotSupported</Name>
-        <DisplayName TxtId="">Service is not supported by server.</DisplayName>
+        <DisplayName TxtId="">Service is not supported by the server.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1794">InvalidIndexGroup</Name>
-        <DisplayName TxtId="">Invalid index group</DisplayName>
+        <DisplayName TxtId="">Invalid index group.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1795">InvalidIndexOffset</Name>
-        <DisplayName TxtId="">Invalid index offset</DisplayName>
+        <DisplayName TxtId="">Invalid index offset.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1796">InvalidAccess</Name>
-        <DisplayName TxtId="">Reading/writing is not permitted.</DisplayName>
+        <DisplayName TxtId="">Reading or writing is not permitted.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48639,12 +53118,12 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1798">InvalidData</Name>
-        <DisplayName TxtId="">Invalid parameter value(s)</DisplayName>
+        <DisplayName TxtId="">Invalid data value(s).</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1799">NotReady</Name>
-        <DisplayName TxtId="">Device is not in a ready state.</DisplayName>
+        <DisplayName TxtId="">Device is not ready to operate.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48654,32 +53133,32 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1801">InvalidContext</Name>
-        <DisplayName TxtId="">Invalid context</DisplayName>
+        <DisplayName TxtId="">Invalid operating system context. This can result from use of ADS function blocks in different tasks.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1802">NoMemory</Name>
-        <DisplayName TxtId="">Out of memory</DisplayName>
+        <DisplayName TxtId="">Insufficient memory.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1803">InvalidParam</Name>
-        <DisplayName TxtId="">Invalid parameter value(s)</DisplayName>
+        <DisplayName TxtId="">Invalid parameter value(s).</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1804">NotFound</Name>
-        <DisplayName TxtId="">Not found (files, ...)</DisplayName>
+        <DisplayName TxtId="">Not found (files, ...).</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1805">Syntax</Name>
-        <DisplayName TxtId="">Syntax error in comand or file</DisplayName>
+        <DisplayName TxtId="">Syntax error in file or command.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1806">Incompatible</Name>
-        <DisplayName TxtId="">Object does not match.</DisplayName>
+        <DisplayName TxtId="">Objects do not match.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48694,12 +53173,12 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1809">SymbolVersionInvalid</Name>
-        <DisplayName TxtId="">Symbol version is invalid. (-&gt; Release handle and try again.)</DisplayName>
+        <DisplayName TxtId="">Invalid symbol version. This can occur due to an online change. Create a new handle.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1810">InvalidState</Name>
-        <DisplayName TxtId="">Server is in invalid state.</DisplayName>
+        <DisplayName TxtId="">Device (server) is in invalid state.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48709,7 +53188,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1812">NotificationHandleInvalid</Name>
-        <DisplayName TxtId="">Notification handle is invalid. (-&gt; Release handle and try again.)</DisplayName>
+        <DisplayName TxtId="">Notification handle is invalid.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48719,12 +53198,12 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1814">NoMoreHandles</Name>
-        <DisplayName TxtId="">No more notification handles</DisplayName>
+        <DisplayName TxtId="">No further notification handles.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1815">InvalidWatchSize</Name>
-        <DisplayName TxtId="">Size for watch is too big.</DisplayName>
+        <DisplayName TxtId="">Notification size too large.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48739,12 +53218,12 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1818">NoInterface</Name>
-        <DisplayName TxtId="">Query interface is failed.</DisplayName>
+        <DisplayName TxtId="">Interface query failed.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1819">InvalidInterface</Name>
-        <DisplayName TxtId="">Wrong interface is required.</DisplayName>
+        <DisplayName TxtId="">Wrong interface is requested.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48759,7 +53238,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1822">Pending</Name>
-        <DisplayName TxtId="">Request is pending.</DisplayName>
+        <DisplayName TxtId="">Request pending.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48769,27 +53248,27 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1824">SignalWarning</Name>
-        <DisplayName TxtId="">Signal warning</DisplayName>
+        <DisplayName TxtId="">Signal warning.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1825">InvalidArrayIndex</Name>
-        <DisplayName TxtId="">Invalid array index</DisplayName>
+        <DisplayName TxtId="">Invalid array index.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1826">SymbolNotActive</Name>
-        <DisplayName TxtId="">Symbol is not active. (-&gt; Release handle and try again.)</DisplayName>
+        <DisplayName TxtId="">Symbol is not active.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1827">AccessDenied</Name>
-        <DisplayName TxtId="">Access is denied.</DisplayName>
+        <DisplayName TxtId="">Access denied.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1828">LicenseMissing</Name>
-        <DisplayName TxtId="">License is missing / not found.</DisplayName>
+        <DisplayName TxtId="">Missing license.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48809,17 +53288,17 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1832">LicenseSystemID</Name>
-        <DisplayName TxtId="">License with invalid system ID</DisplayName>
+        <DisplayName TxtId="">License problem: System ID is invalid.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1833">LicenseNoTimeLimit</Name>
-        <DisplayName TxtId="">License is not time limited.</DisplayName>
+        <DisplayName TxtId="">License not limited in time.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1834">LicenseFutureIssue</Name>
-        <DisplayName TxtId="">License issue time is in the future.</DisplayName>
+        <DisplayName TxtId="">License problem: Time in the future.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48829,7 +53308,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1836">Exception</Name>
-        <DisplayName TxtId="">Exception in the device code</DisplayName>
+        <DisplayName TxtId="">Exception at system startup.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48838,8 +53317,68 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Severity>Error</Severity>
       </EventId>
       <EventId>
+        <Name Id="1838">SignatureInvalid</Name>
+        <DisplayName TxtId="">Invalid signature.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1839">CertificateInvalid</Name>
+        <DisplayName TxtId="">Invalid certificate.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1840">LicenseOEMNotFound</Name>
+        <DisplayName TxtId="">Public key not known from OEM.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1841">LicenseRestricted</Name>
+        <DisplayName TxtId="">License not valid for this system ID.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1842">LicenseDemoDenied</Name>
+        <DisplayName TxtId="">Demo license prohibited.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1843">InvalidFunctionID</Name>
+        <DisplayName TxtId="">Invalid function ID.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1844">OutOfRange</Name>
+        <DisplayName TxtId="">Outside the valid range.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1845">InvalidAlignment</Name>
+        <DisplayName TxtId="">Invalid alignment.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1846">LicensePlatform</Name>
+        <DisplayName TxtId="">Invalid platform level.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1847">ForwardPassiveLevel</Name>
+        <DisplayName TxtId="">Context – forward to passive level.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1848">ForwardDispatchLevel</Name>
+        <DisplayName TxtId="">Context – forward to dispatch level.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1849">ForwardRealTime</Name>
+        <DisplayName TxtId="">Context – forward to real-time.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
         <Name Id="1857">InvalidServiceParam</Name>
-        <DisplayName TxtId="">Invalid parameter at service call</DisplayName>
+        <DisplayName TxtId="">Service contains an invalid parameter.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48859,7 +53398,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1861">TimeoutElapsed</Name>
-        <DisplayName TxtId="">Timeout is elapsed.</DisplayName>
+        <DisplayName TxtId="">Timeout has occurred – the remote terminal is not responding in the specified ADS timeout.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48869,37 +53408,37 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1863">TimeoutInvalid</Name>
-        <DisplayName TxtId="">Timeout value is invalid.</DisplayName>
+        <DisplayName TxtId="">Invalid client timeout value.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1864">PortNotOpen</Name>
-        <DisplayName TxtId="">Port is not open (Ads dll).</DisplayName>
+        <DisplayName TxtId="">Port is not open.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1865">NoAMSAddr</Name>
-        <DisplayName TxtId="">No AMS address (Ads dll)</DisplayName>
+        <DisplayName TxtId="">No AMS address.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1872">SyncInternalError</Name>
-        <DisplayName TxtId="">Internal error in Ads sync</DisplayName>
+        <DisplayName TxtId="">Internal error in Ads sync.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1873">AddHash</Name>
-        <DisplayName TxtId="">Hash table overflow</DisplayName>
+        <DisplayName TxtId="">Hash table overflow.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1874">RemoveHash</Name>
-        <DisplayName TxtId="">Key not found in hash table</DisplayName>
+        <DisplayName TxtId="">Key not found in hash table.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1875">NoMoreSymbols</Name>
-        <DisplayName TxtId="">No more symbols in cache</DisplayName>
+        <DisplayName TxtId="">No symbols in the cache.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48912,31 +53451,258 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <DisplayName TxtId="">Sync port is locked.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
+      <Translations>
+        <Text TxtId="General device error.">
+          <Text LcId="1031">Allgemeiner Gerätefehler.</Text>
+        </Text>
+        <Text TxtId="Service is not supported by the server.">
+          <Text LcId="1031">Service wird vom Server nicht unterstützt.</Text>
+        </Text>
+        <Text TxtId="Invalid index group.">
+          <Text LcId="1031">Ungültige Index-Gruppe.</Text>
+        </Text>
+        <Text TxtId="Invalid index offset.">
+          <Text LcId="1031">Ungültiger Index-Offset.</Text>
+        </Text>
+        <Text TxtId="Reading or writing is not permitted.">
+          <Text LcId="1031">Lesen oder Schreiben ist nicht gestattet.</Text>
+        </Text>
+        <Text TxtId="Parameter size is not correct.">
+          <Text LcId="1031">Parametergröße ist nicht korrekt.</Text>
+        </Text>
+        <Text TxtId="Invalid data value(s).">
+          <Text LcId="1031">Ungültige Daten-Werte.</Text>
+        </Text>
+        <Text TxtId="Device is not ready to operate.">
+          <Text LcId="1031">Gerät ist nicht betriebsbereit.</Text>
+        </Text>
+        <Text TxtId="Device is busy.">
+          <Text LcId="1031">Gerät ist beschäftigt.</Text>
+        </Text>
+        <Text TxtId="Invalid operating system context. This can result from use of ADS function blocks in different tasks.">
+          <Text LcId="1031">Ungültiger Kontext vom Betriebssystem. Kann durch Verwendung von ADS Bausteinen in unterschiedlichen Tasks auftreten.</Text>
+        </Text>
+        <Text TxtId="Insufficient memory.">
+          <Text LcId="1031">Nicht genügend Speicher.</Text>
+        </Text>
+        <Text TxtId="Invalid parameter value(s).">
+          <Text LcId="1031">Ungültige Parameter-Werte.</Text>
+        </Text>
+        <Text TxtId="Not found (files, ...).">
+          <Text LcId="1031">Nicht gefunden (Dateien,...).</Text>
+        </Text>
+        <Text TxtId="Syntax error in file or command.">
+          <Text LcId="1031">Syntax-Fehler in Datei oder Befehl.</Text>
+        </Text>
+        <Text TxtId="Objects do not match.">
+          <Text LcId="1031">Objekte stimmen nicht überein.</Text>
+        </Text>
+        <Text TxtId="Object already exists.">
+          <Text LcId="1031">Objekt ist bereits vorhanden.</Text>
+        </Text>
+        <Text TxtId="Symbol was not found.">
+          <Text LcId="1031">Symbol nicht gefunden.</Text>
+        </Text>
+        <Text TxtId="Invalid symbol version. This can occur due to an online change. Create a new handle.">
+          <Text LcId="1031">Symbol-Version ist ungültig. Kann durch einen Online-Change auftreten. Erzeuge einen neuen Handle.</Text>
+        </Text>
+        <Text TxtId="Device (server) is in invalid state.">
+          <Text LcId="1031">Gerät (Server) ist im ungültigen Zustand.</Text>
+        </Text>
+        <Text TxtId="AdsTransMode is not supported.">
+          <Text LcId="1031">AdsTransMode wird nicht unterstützt.</Text>
+        </Text>
+        <Text TxtId="Notification handle is invalid.">
+          <Text LcId="1031">Notification Handle ist ungültig.</Text>
+        </Text>
+        <Text TxtId="Notification client is not registered.">
+          <Text LcId="1031">Notification-Client nicht registriert. </Text>
+        </Text>
+        <Text TxtId="No further notification handles.">
+          <Text LcId="1031">Keine weiteren Notification Handles.</Text>
+        </Text>
+        <Text TxtId="Notification size too large.">
+          <Text LcId="1031">Größe der Notification zu groß.</Text>
+        </Text>
+        <Text TxtId="Device is not initialized.">
+          <Text LcId="1031">Gerät ist nicht initialisiert.</Text>
+        </Text>
+        <Text TxtId="Device has a timeout.">
+          <Text LcId="1031">Gerät hat einen Timeout.</Text>
+        </Text>
+        <Text TxtId="Interface query failed.">
+          <Text LcId="1031">Interface Abfrage fehlgeschlagen.</Text>
+        </Text>
+        <Text TxtId="Wrong interface is requested.">
+          <Text LcId="1031">Falsches Interface angefordert. </Text>
+        </Text>
+        <Text TxtId="Class ID is invalid.">
+          <Text LcId="1031">Class-ID ist ungültig.</Text>
+        </Text>
+        <Text TxtId="Object ID is invalid.">
+          <Text LcId="1031">Object-ID ist ungültig.</Text>
+        </Text>
+        <Text TxtId="Request pending.">
+          <Text LcId="1031">Anforderung steht aus.</Text>
+        </Text>
+        <Text TxtId="Request is aborted.">
+          <Text LcId="1031">Anforderung wird abgebrochen.</Text>
+        </Text>
+        <Text TxtId="Signal warning.">
+          <Text LcId="1031">Signal-Warnung.</Text>
+        </Text>
+        <Text TxtId="Invalid array index.">
+          <Text LcId="1031">Ungültiger Array-Index.</Text>
+        </Text>
+        <Text TxtId="Symbol is not active.">
+          <Text LcId="1031">Symbol ist nicht aktiv.</Text>
+        </Text>
+        <Text TxtId="Access denied.">
+          <Text LcId="1031">Zugriff verweigert.</Text>
+        </Text>
+        <Text TxtId="Missing license.">
+          <Text LcId="1031">Fehlende Lizenz.</Text>
+        </Text>
+        <Text TxtId="License is expired.">
+          <Text LcId="1031">Lizenz abgelaufen.</Text>
+        </Text>
+        <Text TxtId="License is exceeded.">
+          <Text LcId="1031">Lizenz überschritten.</Text>
+        </Text>
+        <Text TxtId="License is invalid.">
+          <Text LcId="1031">Lizenz ungültig.</Text>
+        </Text>
+        <Text TxtId="License problem: System ID is invalid.">
+          <Text LcId="1031">Lizenzproblem: System-ID ist ungültig.</Text>
+        </Text>
+        <Text TxtId="License not limited in time.">
+          <Text LcId="1031">Lizenz nicht zeitlich begrenzt.</Text>
+        </Text>
+        <Text TxtId="License problem: Time in the future.">
+          <Text LcId="1031">Lizenzproblem: Zeitpunkt in der Zukunft.</Text>
+        </Text>
+        <Text TxtId="License time period is too long.">
+          <Text LcId="1031">Lizenz-Zeitraum ist zu lang.</Text>
+        </Text>
+        <Text TxtId="Exception at system startup.">
+          <Text LcId="1031">Exception beim Systemstart.</Text>
+        </Text>
+        <Text TxtId="License file is read twice.">
+          <Text LcId="1031">Lizenz-Datei zweimal gelesen.</Text>
+        </Text>
+        <Text TxtId="Invalid signature.">
+          <Text LcId="1031">Ungültige Signatur.</Text>
+        </Text>
+        <Text TxtId="Invalid certificate.">
+          <Text LcId="1031">Zertifikat ungültig.</Text>
+        </Text>
+        <Text TxtId="Public key not known from OEM.">
+          <Text LcId="1031">Public Key vom OEM nicht bekannt.</Text>
+        </Text>
+        <Text TxtId="License not valid for this system ID.">
+          <Text LcId="1031">Lizenz nicht gültig für diese System-ID.</Text>
+        </Text>
+        <Text TxtId="Demo license prohibited.">
+          <Text LcId="1031">Demo-Lizenz untersagt.</Text>
+        </Text>
+        <Text TxtId="Invalid function ID.">
+          <Text LcId="1031">Funktions-ID ungültig.</Text>
+        </Text>
+        <Text TxtId="Outside the valid range.">
+          <Text LcId="1031">Außerhalb des gültigen Bereiches.</Text>
+        </Text>
+        <Text TxtId="Invalid alignment.">
+          <Text LcId="1031">Ungültiges Alignment.</Text>
+        </Text>
+        <Text TxtId="Invalid platform level.">
+          <Text LcId="1031">Ungültiger Plattform Level.</Text>
+        </Text>
+        <Text TxtId="Context – forward to passive level.">
+          <Text LcId="1031">Kontext – Weiterleitung zum Passiv-Level.</Text>
+        </Text>
+        <Text TxtId="Context – forward to dispatch level.">
+          <Text LcId="1031">Kontext – Weiterleitung zum Dispatch-Level.</Text>
+        </Text>
+        <Text TxtId="Context – forward to real-time.">
+          <Text LcId="1031">Kontext – Weiterleitung zur Echtzeit.</Text>
+        </Text>
+        <Text TxtId="Service contains an invalid parameter.">
+          <Text LcId="1031">Dienst enthält einen ungültigen Parameter. </Text>
+        </Text>
+        <Text TxtId="Polling list is empty.">
+          <Text LcId="1031">Polling-Liste ist leer.</Text>
+        </Text>
+        <Text TxtId="Variable connection is already in use.">
+          <Text LcId="1031">Variablen-Verbindung bereits im Einsatz.</Text>
+        </Text>
+        <Text TxtId="Invoke ID is already in use.">
+          <Text LcId="1031">Die Invoke-ID ist bereits in Benutzung.</Text>
+        </Text>
+        <Text TxtId="Timeout has occurred – the remote terminal is not responding in the specified ADS timeout.">
+          <Text LcId="1031">Timeout ist aufgetreten – Die Gegenstelle antwortet nicht im vorgegebenen ADS Timeout.</Text>
+        </Text>
+        <Text TxtId="Error in Win32 subsystem">
+          <Text LcId="1031">Fehler im Win32 Subsystem.</Text>
+        </Text>
+        <Text TxtId="Invalid client timeout value.">
+          <Text LcId="1031">Ungültiger Client Timeout-Wert.</Text>
+        </Text>
+        <Text TxtId="Port is not open.">
+          <Text LcId="1031">Port nicht geöffnet.</Text>
+        </Text>
+        <Text TxtId="No AMS address.">
+          <Text LcId="1031">Keine AMS Adresse.</Text>
+        </Text>
+        <Text TxtId="Internal error in Ads sync.">
+          <Text LcId="1031">Interner Fehler in Ads-Sync.</Text>
+        </Text>
+        <Text TxtId="Hash table overflow.">
+          <Text LcId="1031">Überlauf der Hash-Tabelle.</Text>
+        </Text>
+        <Text TxtId="Key not found in hash table.">
+          <Text LcId="1031">Schlüssel in der Hash-Tabelle nicht gefunden.</Text>
+        </Text>
+        <Text TxtId="No symbols in the cache.">
+          <Text LcId="1031">Keine Symbole im Cache.</Text>
+        </Text>
+        <Text TxtId="Invalid response received">
+          <Text LcId="1031">Ungültige Antwort erhalten.</Text>
+        </Text>
+        <Text TxtId="Sync port is locked.">
+          <Text LcId="1031">Sync Port ist verriegelt.</Text>
+        </Text>
+      </Translations>
       <Hides>
         <Hide GUID="{8D937C5B-9A96-4A48-AA0B-BC30CC416A59}"/>
+        <Hide GUID="{B9B139A7-F4EF-4029-AD7B-4532CD350F16}"/>
+        <Hide GUID="{2CA2B7C4-0A28-4A21-B6E4-7E1F3CAFA028}"/>
+        <Hide GUID="{C9B29370-3E32-4D90-82D4-71F4A1DD0FFD}"/>
+        <Hide GUID="{3D60DD34-7572-4DAF-A600-0029A8A10D05}"/>
+        <Hide GUID="{4AADD072-A113-4A0C-BCA5-5DA1F921499A}"/>
+        <Hide GUID="{FDC026E1-568D-488A-BA3A-D57F287E3BC6}"/>
       </Hides>
     </DataType>
     <DataType>
-      <Name GUID="{E3D84344-4CB3-44DB-8D94-12F9CE0E2F90}" TcBaseType="true" CName="TcRouterEventClass">TcRouterEventClass</Name>
+      <Name GUID="{E759605A-2341-48FC-9F3F-C8FA405C4B24}" TcBaseType="true" CName="TcRouterEventClass">TcRouterEventClass</Name>
       <DisplayName TxtId="">TcRouterEventClass</DisplayName>
       <EventId>
         <Name Id="1280">NoLockedMemory</Name>
-        <DisplayName TxtId="">No locked memory can be allocated.</DisplayName>
+        <DisplayName TxtId="">Locked memory cannot be allocated.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1281">ResizeMemory</Name>
-        <DisplayName TxtId="">The size of the router memory could not be changed.</DisplayName>
+        <DisplayName TxtId="">The router memory size could not be changed.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1282">MailboxFull</Name>
-        <DisplayName TxtId="">The mailbox has reached the maximum number of possible messages. The current sent message was rejected.</DisplayName>
+        <DisplayName TxtId="">The mailbox has reached the maximum number of possible messages.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1283">DebugBoxFull</Name>
-        <DisplayName TxtId="">The debug mailbox has reached the maximum number of possible messages. The sent message will not be displayed in the debug monitor.</DisplayName>
+        <DisplayName TxtId="">The debug mailbox has reached the maximum number of possible messages.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48951,17 +53717,17 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1286">PortAlreadyInUse</Name>
-        <DisplayName TxtId="">The desired port number is already assigned.</DisplayName>
+        <DisplayName TxtId="">The port number is already assigned.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1287">NotRegistered</Name>
-        <DisplayName TxtId="">The Port is not registered.</DisplayName>
+        <DisplayName TxtId="">The port is not registered.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1288">NoMoreQueues</Name>
-        <DisplayName TxtId="">The maximum number of Ports is reached.</DisplayName>
+        <DisplayName TxtId="">The maximum number of ports has been reached.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -48976,76 +53742,124 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="1291">FragmentBoxFull</Name>
-        <DisplayName TxtId="">Fragment Box is full.</DisplayName>
+        <DisplayName TxtId="">The mailbox has reached the maximum number for fragmented messages.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1292">FragmentTimeout</Name>
-        <DisplayName TxtId="">Fragment Timeout</DisplayName>
+        <DisplayName TxtId="">A fragment timeout has occurred.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="1293">ToBeRemoved</Name>
-        <DisplayName TxtId="">ToBeRemoved</DisplayName>
+        <DisplayName TxtId="">The port is removed.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
+      <Translations>
+        <Text TxtId="Locked memory cannot be allocated.">
+          <Text LcId="1031">Lockierter Speicher kann nicht zugewiesen werden.</Text>
+        </Text>
+        <Text TxtId="The router memory size could not be changed.">
+          <Text LcId="1031">Die Größe des Routerspeichers konnte nicht geändert werden.</Text>
+        </Text>
+        <Text TxtId="The mailbox has reached the maximum number of possible messages.">
+          <Text LcId="1031">Das Postfach hat die maximale Anzahl der möglichen Meldungen erreicht.</Text>
+        </Text>
+        <Text TxtId="The debug mailbox has reached the maximum number of possible messages.">
+          <Text LcId="1031">Das Debug Postfach hat die maximale Anzahl der möglichen Meldungen erreicht.</Text>
+        </Text>
+        <Text TxtId="The port type is unknown.">
+          <Text LcId="1031">Der Porttyp ist unbekannt.</Text>
+        </Text>
+        <Text TxtId="TwinCAT Router is not initialised.">
+          <Text LcId="1031">Der TwinCAT Router ist nicht initialisiert.</Text>
+        </Text>
+        <Text TxtId="The port number is already assigned.">
+          <Text LcId="1031">Die Portnummer ist bereits vergeben.</Text>
+        </Text>
+        <Text TxtId="The port is not registered.">
+          <Text LcId="1031">Der Port ist nicht registriert.</Text>
+        </Text>
+        <Text TxtId="The maximum number of ports has been reached.">
+          <Text LcId="1031">Die maximale Portanzahl ist erreicht.</Text>
+        </Text>
+        <Text TxtId="The port is invalid.">
+          <Text LcId="1031">Der Port ist ungültig.</Text>
+        </Text>
+        <Text TxtId="TwinCAT Router is not active.">
+          <Text LcId="1031">Der TwinCAT Router ist nicht aktiv.</Text>
+        </Text>
+        <Text TxtId="The mailbox has reached the maximum number for fragmented messages.">
+          <Text LcId="1031">Das Postfach hat die maximale Anzahl für fragmentierte Nachrichten erreicht.</Text>
+        </Text>
+        <Text TxtId="A fragment timeout has occurred.">
+          <Text LcId="1031">Fragment Timeout aufgetreten.</Text>
+        </Text>
+        <Text TxtId="The port is removed.">
+          <Text LcId="1031">Port wird entfernt.</Text>
+        </Text>
+      </Translations>
+      <Hides>
+        <Hide GUID="{E3D84344-4CB3-44DB-8D94-12F9CE0E2F90}"/>
+        <Hide GUID="{87452E42-EDD9-4DFF-AE3D-F4ED89F67122}"/>
+      </Hides>
     </DataType>
     <DataType>
-      <Name GUID="{B63588AE-B30A-4DCE-A44F-F929FB114944}" TcBaseType="true" CName="TcRTimeEventClass">TcRTimeEventClass</Name>
+      <Name GUID="{92F05393-06A8-48C2-8871-EAA38C1E3990}" TcBaseType="true" CName="TcRTimeEventClass">TcRTimeEventClass</Name>
       <DisplayName TxtId="">TcRTimeEventClass</DisplayName>
       <EventId>
         <Name Id="4096">InternalError</Name>
-        <DisplayName TxtId="">An internal fatal error in the TwinCAT real-time system occurred.</DisplayName>
+        <DisplayName TxtId="">Internal error in the real-time system.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4097">BadTimerPeriods</Name>
-        <DisplayName TxtId="">The timer period is invalid.</DisplayName>
+        <DisplayName TxtId="">Timer value is not valid.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4098">InvalidTaskPtr</Name>
-        <DisplayName TxtId="">The task pointer has the invalid value ZERO.</DisplayName>
+        <DisplayName TxtId="">The task pointer has the invalid value 0 (null).</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4099">InvalidStackPtr</Name>
-        <DisplayName TxtId="">The task stack pointer has the invalid value ZERO.</DisplayName>
+        <DisplayName TxtId="">The stack pointer has the invalid value 0 (null).</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4100">PrioExists</Name>
-        <DisplayName TxtId="">The demanded task priority is already assigned.</DisplayName>
+        <DisplayName TxtId="">The task priority is already assigned.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4101">NoMoreTCB</Name>
-        <DisplayName TxtId="">No more free TCB (Task Control Block) available. The maximum number of TCBs is 64.</DisplayName>
+        <DisplayName TxtId="">No free TCB (Task Control Block) available. The maximum number of TCBs is 64.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4102">NoMoreSemas</Name>
-        <DisplayName TxtId="">No more free semaphores available. The maximum number of semaphores is 64.</DisplayName>
+        <DisplayName TxtId="">No free semaphores available. The maximum number of semaphores is 64.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4103">NoMoreQueues</Name>
-        <DisplayName TxtId="">No more free queues available. The maximum number of queues is 64.</DisplayName>
+        <DisplayName TxtId="">No free space available in the queue. The maximum number of positions in the queue is 64.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4109">ExtIRQAlreadyDef</Name>
-        <DisplayName TxtId="">An external synchronisation interrupt is already applied.</DisplayName>
+        <DisplayName TxtId="">An external synchronization interrupt is already applied.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4110">ExtIRQNotDef</Name>
-        <DisplayName TxtId="">No external synchronsiation interrupt is applied.</DisplayName>
+        <DisplayName TxtId="">No external synchronziation interrupt applied.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4111">ExtIRQInstallFailed</Name>
-        <DisplayName TxtId="">The apply of the external synchronisation interrupt failed.</DisplayName>
+        <DisplayName TxtId="">Application of the external synchronization interrupt failed.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
@@ -49060,19 +53874,74 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EventId>
       <EventId>
         <Name Id="4120">VMXDisabled</Name>
-        <DisplayName TxtId="">Intel VT-x extension is not enabled in BIOS.</DisplayName>
+        <DisplayName TxtId="">Intel VT-x extension is not enabled in the BIOS.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4121">VMXControlsMissing</Name>
-        <DisplayName TxtId="">Missing feature in Intel VT-x extension.</DisplayName>
+        <DisplayName TxtId="">Missing function in Intel VT-x extension.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
       <EventId>
         <Name Id="4122">VMXEnableFails</Name>
-        <DisplayName TxtId="">Enabling Intel VT-x fails.</DisplayName>
+        <DisplayName TxtId="">Activation of Intel VT-x fails.</DisplayName>
         <Severity>Error</Severity>
       </EventId>
+      <Translations>
+        <Text TxtId="Internal error in the real-time system.">
+          <Text LcId="1031">Interner Fehler im Echtzeit-System.</Text>
+        </Text>
+        <Text TxtId="Timer value is not valid.">
+          <Text LcId="1031">Timer-Wert ist nicht gültig.</Text>
+        </Text>
+        <Text TxtId="The task pointer has the invalid value 0 (null).">
+          <Text LcId="1031">Task-Pointer hat den ungültigen Wert 0 (null).</Text>
+        </Text>
+        <Text TxtId="The stack pointer has the invalid value 0 (null).">
+          <Text LcId="1031">Stack-Pointer hat den ungültigen Wert 0 (null).</Text>
+        </Text>
+        <Text TxtId="The task priority is already assigned.">
+          <Text LcId="1031">Die Task Priority ist bereits vergeben.</Text>
+        </Text>
+        <Text TxtId="No free TCB (Task Control Block) available. The maximum number of TCBs is 64.">
+          <Text LcId="1031">Kein freier TCB (Task Control Block) verfügbar. Maximale Anzahl von TCBs beträgt 64.</Text>
+        </Text>
+        <Text TxtId="No free semaphores available. The maximum number of semaphores is 64.">
+          <Text LcId="1031">Keine freien Semaphoren zur Verfügung. Maximale Anzahl der Semaphoren beträgt 64.</Text>
+        </Text>
+        <Text TxtId="No free space available in the queue. The maximum number of positions in the queue is 64.">
+          <Text LcId="1031">Kein freier Platz in der Warteschlange zur Verfügung. Maximale Anzahl der Plätze in der Warteschlange beträgt 64.</Text>
+        </Text>
+        <Text TxtId="An external synchronization interrupt is already applied.">
+          <Text LcId="1031">Ein externer Synchronisations-Interrupt wird bereits angewandt.</Text>
+        </Text>
+        <Text TxtId="No external synchronziation interrupt applied.">
+          <Text LcId="1031">Kein externer Synchronisations-Interrupt angewandt.</Text>
+        </Text>
+        <Text TxtId="Application of the external synchronization interrupt failed.">
+          <Text LcId="1031">Anwendung des externen Synchronisations-Interrupts ist fehlgeschlagen.</Text>
+        </Text>
+        <Text TxtId="Call of a service function in the wrong context.">
+          <Text LcId="1031">Aufruf einer Service-Funktion im falschen Kontext</Text>
+        </Text>
+        <Text TxtId="Intel VT-x extension is not supported.">
+          <Text LcId="1031">Intel VT-x Erweiterung wird nicht unterstützt.</Text>
+        </Text>
+        <Text TxtId="Intel VT-x extension is not enabled in the BIOS.">
+          <Text LcId="1031">Intel VT-x Erweiterung ist nicht aktiviert im BIOS.</Text>
+        </Text>
+        <Text TxtId="Missing function in Intel VT-x extension.">
+          <Text LcId="1031">Fehlende Funktion in Intel VT-x Erweiterung.</Text>
+        </Text>
+        <Text TxtId="Activation of Intel VT-x fails.">
+          <Text LcId="1031">Aktivieren von Intel VT-x schlägt fehl.</Text>
+        </Text>
+      </Translations>
+      <Hides>
+        <Hide GUID="{B63588AE-B30A-4DCE-A44F-F929FB114944}"/>
+        <Hide GUID="{8E99B0A5-4A45-447F-8419-990947BADC05}"/>
+        <Hide GUID="{677C6993-DDDD-4030-909A-ED03B92876B5}"/>
+      </Hides>
     </DataType>
     <DataType>
       <Name GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}" TcBaseType="true" CName="Win32EventClass">Win32EventClass</Name>
@@ -49416,7 +54285,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_MR1L3</Name>
             <Comment> M1L3 In Serial Comm Array</Comment>
@@ -49457,7 +54326,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657536880</BitOffs>
+            <BitOffs>656534288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_MR1L4</Name>
@@ -49498,7 +54367,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657537264</BitOffs>
+            <BitOffs>656534672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_MR2L3</Name>
@@ -49540,14 +54409,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657537648</BitOffs>
+            <BitOffs>656535056</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_MR1L3</Name>
             <Comment> M1 Out Serual Comm Array</Comment>
@@ -49587,7 +54456,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657537072</BitOffs>
+            <BitOffs>656534480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_MR1L4</Name>
@@ -49628,7 +54497,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657537456</BitOffs>
+            <BitOffs>656534864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_MR2L3</Name>
@@ -49669,33 +54538,33 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657537840</BitOffs>
+            <BitOffs>656535248</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_MR1L3</Name>
             <Comment> M1 Serial Comm Function Block</Comment>
             <BitSize>10432</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>634655584</BitOffs>
+            <BitOffs>652709312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_MR1L4</Name>
             <Comment> M1 Serial Comm Function Block</Comment>
             <BitSize>10432</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>634666016</BitOffs>
+            <BitOffs>652719744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_MR2L3</Name>
             <BitSize>10432</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>634676448</BitOffs>
+            <BitOffs>652730176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_MR1L3</Name>
@@ -49707,7 +54576,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434688</BitOffs>
+            <BitOffs>654432128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_MR1L3</Name>
@@ -49718,7 +54587,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655437200</BitOffs>
+            <BitOffs>654434640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_MR1L4</Name>
@@ -49729,7 +54598,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655439712</BitOffs>
+            <BitOffs>654437152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_MR1L4</Name>
@@ -49740,7 +54609,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655442224</BitOffs>
+            <BitOffs>654439664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_MR2L3</Name>
@@ -49751,7 +54620,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655444736</BitOffs>
+            <BitOffs>654442176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_MR2L3</Name>
@@ -49762,7 +54631,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655447248</BitOffs>
+            <BitOffs>654444688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -49776,7 +54645,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657540352</BitOffs>
+            <BitOffs>656537760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -49790,7 +54659,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657545472</BitOffs>
+            <BitOffs>656539808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -49804,7 +54673,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657545504</BitOffs>
+            <BitOffs>656542912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -49825,14 +54694,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657545664</BitOffs>
+            <BitOffs>656543072</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
             <Comment> Global hash prefix type constant used for binary, octal or hexadecimal string format type </Comment>
@@ -49846,7 +54715,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184944</BitOffs>
+            <BitOffs>3160944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_MAX_ARGS</Name>
@@ -49861,7 +54730,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248320</BitOffs>
+            <BitOffs>3224320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_NAN</Name>
@@ -49876,7 +54745,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248336</BitOffs>
+            <BitOffs>3224336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_INF</Name>
@@ -49891,7 +54760,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248352</BitOffs>
+            <BitOffs>3224352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_DIGITS</Name>
@@ -49906,7 +54775,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248368</BitOffs>
+            <BitOffs>3224368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_PRECISION</Name>
@@ -49921,7 +54790,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248384</BitOffs>
+            <BitOffs>3224384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MIN_PRECISION</Name>
@@ -49936,7 +54805,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248400</BitOffs>
+            <BitOffs>3224400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_NOERROR</Name>
@@ -49951,7 +54820,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248416</BitOffs>
+            <BitOffs>3224416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PERCENTSIGNPOSITION</Name>
@@ -49966,7 +54835,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248448</BitOffs>
+            <BitOffs>3224448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ASTERISKPOSITION</Name>
@@ -49981,7 +54850,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248480</BitOffs>
+            <BitOffs>3224480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHVALUE</Name>
@@ -49996,7 +54865,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248512</BitOffs>
+            <BitOffs>3224512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONVALUE</Name>
@@ -50011,7 +54880,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248544</BitOffs>
+            <BitOffs>3224544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_FLAGPOSITION</Name>
@@ -50026,7 +54895,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248576</BitOffs>
+            <BitOffs>3224576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHPRECISIONVALPOS</Name>
@@ -50041,7 +54910,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248608</BitOffs>
+            <BitOffs>3224608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONDOTPOSITION</Name>
@@ -50056,7 +54925,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248640</BitOffs>
+            <BitOffs>3224640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ARGTYPEINVALID</Name>
@@ -50071,7 +54940,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248704</BitOffs>
+            <BitOffs>3224704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_UNACCEPTEDPARAMETER</Name>
@@ -50086,7 +54955,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248736</BitOffs>
+            <BitOffs>3224736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INSUFFICIENTARGS</Name>
@@ -50101,7 +54970,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248768</BitOffs>
+            <BitOffs>3224768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_DESTBUFFOVERFLOW</Name>
@@ -50116,7 +54985,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248800</BitOffs>
+            <BitOffs>3224800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_HEXASC_CODES</Name>
@@ -50265,27 +55134,27 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248960</BitOffs>
+            <BitOffs>3224960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_MR1L3</Name>
             <Comment>PI Serial
 Beckhoff</Comment>
-            <BitSize>104032</BitSize>
+            <BitSize>109632</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>634688416</BitOffs>
+            <BitOffs>633633440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_MR2L3</Name>
-            <BitSize>104032</BitSize>
+            <BitSize>109632</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>634792736</BitOffs>
+            <BitOffs>633743360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_MR1L4</Name>
-            <BitSize>104032</BitSize>
+            <BitSize>109632</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>634897056</BitOffs>
+            <BitOffs>633853280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3.MR1L3_Pitch</Name>
@@ -50319,7 +55188,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655449920</BitOffs>
+            <BitOffs>654447360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4.MR1L4_Pitch</Name>
@@ -50353,7 +55222,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655452672</BitOffs>
+            <BitOffs>654450112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3.MR2L3_Pitch</Name>
@@ -50387,7 +55256,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455680</BitOffs>
+            <BitOffs>654453120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -50401,7 +55270,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657545536</BitOffs>
+            <BitOffs>656542944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -50415,7 +55284,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657545568</BitOffs>
+            <BitOffs>656542976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -50436,14 +55305,14 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657546368</BitOffs>
+            <BitOffs>656543776</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">32</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -50455,19 +55324,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634621504</BitOffs>
+            <BitOffs>633597568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635016832</BitOffs>
+            <BitOffs>633978624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -50490,7 +55359,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024832</BitOffs>
+            <BitOffs>633986624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -50513,7 +55382,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024840</BitOffs>
+            <BitOffs>633986632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -50536,7 +55405,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024848</BitOffs>
+            <BitOffs>633986640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -50559,7 +55428,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024864</BitOffs>
+            <BitOffs>633986656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -50572,7 +55441,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024896</BitOffs>
+            <BitOffs>633986688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -50585,7 +55454,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024960</BitOffs>
+            <BitOffs>633986752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -50598,31 +55467,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024976</BitOffs>
+            <BitOffs>633986768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635039488</BitOffs>
+            <BitOffs>634001280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635337472</BitOffs>
+            <BitOffs>634299264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -50645,7 +55514,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635345472</BitOffs>
+            <BitOffs>634307264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -50668,7 +55537,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635345480</BitOffs>
+            <BitOffs>634307272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -50691,7 +55560,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635345488</BitOffs>
+            <BitOffs>634307280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -50714,7 +55583,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635345504</BitOffs>
+            <BitOffs>634307296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -50727,7 +55596,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635345536</BitOffs>
+            <BitOffs>634307328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -50740,7 +55609,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635345600</BitOffs>
+            <BitOffs>634307392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -50753,31 +55622,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635345616</BitOffs>
+            <BitOffs>634307408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635360128</BitOffs>
+            <BitOffs>634321920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635658112</BitOffs>
+            <BitOffs>634619904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -50800,7 +55669,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635666112</BitOffs>
+            <BitOffs>634627904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -50823,7 +55692,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635666120</BitOffs>
+            <BitOffs>634627912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -50846,7 +55715,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635666128</BitOffs>
+            <BitOffs>634627920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -50869,7 +55738,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635666144</BitOffs>
+            <BitOffs>634627936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -50882,7 +55751,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635666176</BitOffs>
+            <BitOffs>634627968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -50895,7 +55764,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635666240</BitOffs>
+            <BitOffs>634628032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -50908,31 +55777,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635666256</BitOffs>
+            <BitOffs>634628048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635680768</BitOffs>
+            <BitOffs>634642560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635978752</BitOffs>
+            <BitOffs>634940544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -50955,7 +55824,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986752</BitOffs>
+            <BitOffs>634948544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -50978,7 +55847,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986760</BitOffs>
+            <BitOffs>634948552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -51001,7 +55870,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986768</BitOffs>
+            <BitOffs>634948560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -51024,7 +55893,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986784</BitOffs>
+            <BitOffs>634948576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -51037,7 +55906,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986816</BitOffs>
+            <BitOffs>634948608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -51050,7 +55919,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986880</BitOffs>
+            <BitOffs>634948672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -51063,31 +55932,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986896</BitOffs>
+            <BitOffs>634948688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636001408</BitOffs>
+            <BitOffs>634963200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636299392</BitOffs>
+            <BitOffs>635261184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -51110,7 +55979,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636307392</BitOffs>
+            <BitOffs>635269184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -51133,7 +56002,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636307400</BitOffs>
+            <BitOffs>635269192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -51156,7 +56025,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636307408</BitOffs>
+            <BitOffs>635269200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -51179,7 +56048,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636307424</BitOffs>
+            <BitOffs>635269216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -51192,7 +56061,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636307456</BitOffs>
+            <BitOffs>635269248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -51205,7 +56074,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636307520</BitOffs>
+            <BitOffs>635269312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -51218,31 +56087,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636307536</BitOffs>
+            <BitOffs>635269328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636322048</BitOffs>
+            <BitOffs>635283840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636620032</BitOffs>
+            <BitOffs>635581824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -51265,7 +56134,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636628032</BitOffs>
+            <BitOffs>635589824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -51288,7 +56157,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636628040</BitOffs>
+            <BitOffs>635589832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -51311,7 +56180,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636628048</BitOffs>
+            <BitOffs>635589840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -51334,7 +56203,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636628064</BitOffs>
+            <BitOffs>635589856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -51347,7 +56216,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636628096</BitOffs>
+            <BitOffs>635589888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -51360,7 +56229,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636628160</BitOffs>
+            <BitOffs>635589952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -51373,19 +56242,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636628176</BitOffs>
+            <BitOffs>635589968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636642688</BitOffs>
+            <BitOffs>635604480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.bSTOEnable1</Name>
@@ -51398,7 +56267,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636940512</BitOffs>
+            <BitOffs>635902304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.bSTOEnable2</Name>
@@ -51410,7 +56279,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636940520</BitOffs>
+            <BitOffs>635902312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stYupEnc</Name>
@@ -51423,7 +56292,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636940544</BitOffs>
+            <BitOffs>635902336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stYdwnEnc</Name>
@@ -51435,7 +56304,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636940672</BitOffs>
+            <BitOffs>635902464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stXupEnc</Name>
@@ -51447,7 +56316,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636940800</BitOffs>
+            <BitOffs>635902592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stXdwnEnc</Name>
@@ -51459,7 +56328,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636940928</BitOffs>
+            <BitOffs>635902720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -51472,7 +56341,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636941504</BitOffs>
+            <BitOffs>635903296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -51485,7 +56354,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636941632</BitOffs>
+            <BitOffs>635903424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -51498,7 +56367,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636950976</BitOffs>
+            <BitOffs>635912768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -51511,7 +56380,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636951104</BitOffs>
+            <BitOffs>635912896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
@@ -51524,7 +56393,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636961248</BitOffs>
+            <BitOffs>635923040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.bSTOEnable2</Name>
@@ -51536,7 +56405,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636961256</BitOffs>
+            <BitOffs>635923048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stYupEnc</Name>
@@ -51549,7 +56418,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636961280</BitOffs>
+            <BitOffs>635923072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
@@ -51561,7 +56430,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636961408</BitOffs>
+            <BitOffs>635923200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stXupEnc</Name>
@@ -51573,7 +56442,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636961536</BitOffs>
+            <BitOffs>635923328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
@@ -51585,7 +56454,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636961664</BitOffs>
+            <BitOffs>635923456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -51598,7 +56467,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636962240</BitOffs>
+            <BitOffs>635924032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -51611,7 +56480,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636962368</BitOffs>
+            <BitOffs>635924160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -51624,7 +56493,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636971712</BitOffs>
+            <BitOffs>635933504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -51637,19 +56506,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636971840</BitOffs>
+            <BitOffs>635933632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636982080</BitOffs>
+            <BitOffs>635943872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
@@ -51672,7 +56541,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636990080</BitOffs>
+            <BitOffs>635951872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
@@ -51695,7 +56564,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636990088</BitOffs>
+            <BitOffs>635951880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bHome</Name>
@@ -51718,7 +56587,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636990096</BitOffs>
+            <BitOffs>635951888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bHardwareEnable</Name>
@@ -51741,7 +56610,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636990112</BitOffs>
+            <BitOffs>635951904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
@@ -51754,7 +56623,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636990144</BitOffs>
+            <BitOffs>635951936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
@@ -51767,7 +56636,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636990208</BitOffs>
+            <BitOffs>635952000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderINT</Name>
@@ -51780,19 +56649,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636990224</BitOffs>
+            <BitOffs>635952016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637003328</BitOffs>
+            <BitOffs>635965120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
@@ -51815,7 +56684,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637011328</BitOffs>
+            <BitOffs>635973120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
@@ -51838,7 +56707,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637011336</BitOffs>
+            <BitOffs>635973128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bHome</Name>
@@ -51861,7 +56730,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637011344</BitOffs>
+            <BitOffs>635973136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bHardwareEnable</Name>
@@ -51884,7 +56753,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637011360</BitOffs>
+            <BitOffs>635973152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
@@ -51897,7 +56766,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637011392</BitOffs>
+            <BitOffs>635973184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
@@ -51910,7 +56779,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637011456</BitOffs>
+            <BitOffs>635973248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderINT</Name>
@@ -51923,31 +56792,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637011472</BitOffs>
+            <BitOffs>635973264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639020864</BitOffs>
+            <BitOffs>637984000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639330176</BitOffs>
+            <BitOffs>638293376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -51970,7 +56839,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639338176</BitOffs>
+            <BitOffs>638301376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -51993,7 +56862,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639338184</BitOffs>
+            <BitOffs>638301384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -52016,7 +56885,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639338192</BitOffs>
+            <BitOffs>638301392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -52039,7 +56908,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639338208</BitOffs>
+            <BitOffs>638301408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -52052,7 +56921,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639338240</BitOffs>
+            <BitOffs>638301440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -52065,7 +56934,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639338304</BitOffs>
+            <BitOffs>638301504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -52078,31 +56947,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639338320</BitOffs>
+            <BitOffs>638301520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m7.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639352832</BitOffs>
+            <BitOffs>638316032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639650816</BitOffs>
+            <BitOffs>638614016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -52125,7 +56994,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639658816</BitOffs>
+            <BitOffs>638622016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -52148,7 +57017,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639658824</BitOffs>
+            <BitOffs>638622024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -52171,7 +57040,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639658832</BitOffs>
+            <BitOffs>638622032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -52194,7 +57063,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639658848</BitOffs>
+            <BitOffs>638622048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -52207,7 +57076,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639658880</BitOffs>
+            <BitOffs>638622080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -52220,7 +57089,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639658944</BitOffs>
+            <BitOffs>638622144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -52233,31 +57102,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639658960</BitOffs>
+            <BitOffs>638622160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m8.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639673472</BitOffs>
+            <BitOffs>638636672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639971456</BitOffs>
+            <BitOffs>638934656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -52280,7 +57149,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639979456</BitOffs>
+            <BitOffs>638942656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -52303,7 +57172,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639979464</BitOffs>
+            <BitOffs>638942664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -52326,7 +57195,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639979472</BitOffs>
+            <BitOffs>638942672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -52349,7 +57218,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639979488</BitOffs>
+            <BitOffs>638942688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -52362,7 +57231,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639979520</BitOffs>
+            <BitOffs>638942720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -52375,7 +57244,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639979584</BitOffs>
+            <BitOffs>638942784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -52388,31 +57257,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639979600</BitOffs>
+            <BitOffs>638942800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m9.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639994112</BitOffs>
+            <BitOffs>638957312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640292096</BitOffs>
+            <BitOffs>639255296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -52435,7 +57304,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640300096</BitOffs>
+            <BitOffs>639263296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -52458,7 +57327,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640300104</BitOffs>
+            <BitOffs>639263304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -52481,7 +57350,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640300112</BitOffs>
+            <BitOffs>639263312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -52504,7 +57373,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640300128</BitOffs>
+            <BitOffs>639263328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -52517,7 +57386,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640300160</BitOffs>
+            <BitOffs>639263360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -52530,7 +57399,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640300224</BitOffs>
+            <BitOffs>639263424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -52543,31 +57412,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640300240</BitOffs>
+            <BitOffs>639263440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m10.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640314752</BitOffs>
+            <BitOffs>639277952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640612736</BitOffs>
+            <BitOffs>639575936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -52590,7 +57459,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640620736</BitOffs>
+            <BitOffs>639583936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -52613,7 +57482,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640620744</BitOffs>
+            <BitOffs>639583944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -52636,7 +57505,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640620752</BitOffs>
+            <BitOffs>639583952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -52659,7 +57528,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640620768</BitOffs>
+            <BitOffs>639583968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -52672,7 +57541,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640620800</BitOffs>
+            <BitOffs>639584000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -52685,7 +57554,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640620864</BitOffs>
+            <BitOffs>639584064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -52698,31 +57567,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640620880</BitOffs>
+            <BitOffs>639584080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m11.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640635392</BitOffs>
+            <BitOffs>639598592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640933376</BitOffs>
+            <BitOffs>639896576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -52745,7 +57614,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640941376</BitOffs>
+            <BitOffs>639904576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -52768,7 +57637,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640941384</BitOffs>
+            <BitOffs>639904584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -52791,7 +57660,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640941392</BitOffs>
+            <BitOffs>639904592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -52814,7 +57683,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640941408</BitOffs>
+            <BitOffs>639904608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -52827,7 +57696,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640941440</BitOffs>
+            <BitOffs>639904640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -52840,7 +57709,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640941504</BitOffs>
+            <BitOffs>639904704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -52853,19 +57722,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640941520</BitOffs>
+            <BitOffs>639904720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640956032</BitOffs>
+            <BitOffs>639919232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.bSTOEnable1</Name>
@@ -52878,7 +57747,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641253856</BitOffs>
+            <BitOffs>640217056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.bSTOEnable2</Name>
@@ -52890,7 +57759,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641253864</BitOffs>
+            <BitOffs>640217064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stYupEnc</Name>
@@ -52903,7 +57772,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641253888</BitOffs>
+            <BitOffs>640217088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stYdwnEnc</Name>
@@ -52915,7 +57784,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641254016</BitOffs>
+            <BitOffs>640217216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stXupEnc</Name>
@@ -52927,7 +57796,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641254144</BitOffs>
+            <BitOffs>640217344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stXdwnEnc</Name>
@@ -52939,7 +57808,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641254272</BitOffs>
+            <BitOffs>640217472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -52952,7 +57821,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641254848</BitOffs>
+            <BitOffs>640218048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -52965,7 +57834,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641254976</BitOffs>
+            <BitOffs>640218176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -52978,7 +57847,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641264320</BitOffs>
+            <BitOffs>640227520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -52991,7 +57860,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641264448</BitOffs>
+            <BitOffs>640227648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
@@ -53004,7 +57873,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641274592</BitOffs>
+            <BitOffs>640237792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.bSTOEnable2</Name>
@@ -53016,7 +57885,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641274600</BitOffs>
+            <BitOffs>640237800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stYupEnc</Name>
@@ -53029,7 +57898,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641274624</BitOffs>
+            <BitOffs>640237824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
@@ -53041,7 +57910,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641274752</BitOffs>
+            <BitOffs>640237952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stXupEnc</Name>
@@ -53053,7 +57922,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641274880</BitOffs>
+            <BitOffs>640238080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
@@ -53065,7 +57934,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641275008</BitOffs>
+            <BitOffs>640238208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -53078,7 +57947,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641275584</BitOffs>
+            <BitOffs>640238784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -53091,7 +57960,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641275712</BitOffs>
+            <BitOffs>640238912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -53104,7 +57973,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641285056</BitOffs>
+            <BitOffs>640248256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -53117,19 +57986,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641285184</BitOffs>
+            <BitOffs>640248384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641295424</BitOffs>
+            <BitOffs>640258624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
@@ -53152,7 +58021,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641303424</BitOffs>
+            <BitOffs>640266624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
@@ -53175,7 +58044,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641303432</BitOffs>
+            <BitOffs>640266632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bHome</Name>
@@ -53198,7 +58067,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641303440</BitOffs>
+            <BitOffs>640266640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bHardwareEnable</Name>
@@ -53221,7 +58090,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641303456</BitOffs>
+            <BitOffs>640266656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
@@ -53234,7 +58103,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641303488</BitOffs>
+            <BitOffs>640266688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
@@ -53247,7 +58116,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641303552</BitOffs>
+            <BitOffs>640266752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderINT</Name>
@@ -53260,19 +58129,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641303568</BitOffs>
+            <BitOffs>640266768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641316672</BitOffs>
+            <BitOffs>640279872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
@@ -53295,7 +58164,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641324672</BitOffs>
+            <BitOffs>640287872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
@@ -53318,7 +58187,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641324680</BitOffs>
+            <BitOffs>640287880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bHome</Name>
@@ -53341,7 +58210,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641324688</BitOffs>
+            <BitOffs>640287888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bHardwareEnable</Name>
@@ -53364,7 +58233,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641324704</BitOffs>
+            <BitOffs>640287904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
@@ -53377,7 +58246,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641324736</BitOffs>
+            <BitOffs>640287936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
@@ -53390,7 +58259,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641324800</BitOffs>
+            <BitOffs>640288000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderINT</Name>
@@ -53403,31 +58272,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641324816</BitOffs>
+            <BitOffs>640288016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643334208</BitOffs>
+            <BitOffs>642298752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643643520</BitOffs>
+            <BitOffs>642608064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -53450,7 +58319,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643651520</BitOffs>
+            <BitOffs>642616064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -53473,7 +58342,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643651528</BitOffs>
+            <BitOffs>642616072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -53496,7 +58365,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643651536</BitOffs>
+            <BitOffs>642616080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -53519,7 +58388,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643651552</BitOffs>
+            <BitOffs>642616096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -53532,7 +58401,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643651584</BitOffs>
+            <BitOffs>642616128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -53545,7 +58414,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643651648</BitOffs>
+            <BitOffs>642616192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -53558,31 +58427,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643651664</BitOffs>
+            <BitOffs>642616208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643666176</BitOffs>
+            <BitOffs>642630720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643964160</BitOffs>
+            <BitOffs>642928704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -53605,7 +58474,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643972160</BitOffs>
+            <BitOffs>642936704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -53628,7 +58497,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643972168</BitOffs>
+            <BitOffs>642936712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -53651,7 +58520,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643972176</BitOffs>
+            <BitOffs>642936720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -53674,7 +58543,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643972192</BitOffs>
+            <BitOffs>642936736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -53687,7 +58556,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643972224</BitOffs>
+            <BitOffs>642936768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -53700,7 +58569,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643972288</BitOffs>
+            <BitOffs>642936832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -53713,31 +58582,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643972304</BitOffs>
+            <BitOffs>642936848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643986816</BitOffs>
+            <BitOffs>642951360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644284800</BitOffs>
+            <BitOffs>643249344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -53760,7 +58629,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644292800</BitOffs>
+            <BitOffs>643257344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -53783,7 +58652,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644292808</BitOffs>
+            <BitOffs>643257352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -53806,7 +58675,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644292816</BitOffs>
+            <BitOffs>643257360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -53829,7 +58698,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644292832</BitOffs>
+            <BitOffs>643257376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -53842,7 +58711,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644292864</BitOffs>
+            <BitOffs>643257408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -53855,7 +58724,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644292928</BitOffs>
+            <BitOffs>643257472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -53868,31 +58737,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644292944</BitOffs>
+            <BitOffs>643257488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644307456</BitOffs>
+            <BitOffs>643272000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644605440</BitOffs>
+            <BitOffs>643569984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -53915,7 +58784,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644613440</BitOffs>
+            <BitOffs>643577984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -53938,7 +58807,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644613448</BitOffs>
+            <BitOffs>643577992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -53961,7 +58830,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644613456</BitOffs>
+            <BitOffs>643578000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -53984,7 +58853,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644613472</BitOffs>
+            <BitOffs>643578016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -53997,7 +58866,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644613504</BitOffs>
+            <BitOffs>643578048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -54010,7 +58879,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644613568</BitOffs>
+            <BitOffs>643578112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -54023,31 +58892,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644613584</BitOffs>
+            <BitOffs>643578128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644628096</BitOffs>
+            <BitOffs>643592640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644926080</BitOffs>
+            <BitOffs>643890624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -54070,7 +58939,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644934080</BitOffs>
+            <BitOffs>643898624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -54093,7 +58962,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644934088</BitOffs>
+            <BitOffs>643898632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -54116,7 +58985,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644934096</BitOffs>
+            <BitOffs>643898640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -54139,7 +59008,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644934112</BitOffs>
+            <BitOffs>643898656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -54152,7 +59021,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644934144</BitOffs>
+            <BitOffs>643898688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -54165,7 +59034,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644934208</BitOffs>
+            <BitOffs>643898752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -54178,31 +59047,31 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644934224</BitOffs>
+            <BitOffs>643898768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644948736</BitOffs>
+            <BitOffs>643913280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645246720</BitOffs>
+            <BitOffs>644211264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -54225,7 +59094,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645254720</BitOffs>
+            <BitOffs>644219264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -54248,7 +59117,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645254728</BitOffs>
+            <BitOffs>644219272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -54271,7 +59140,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645254736</BitOffs>
+            <BitOffs>644219280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -54294,7 +59163,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645254752</BitOffs>
+            <BitOffs>644219296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -54307,7 +59176,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645254784</BitOffs>
+            <BitOffs>644219328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -54320,7 +59189,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645254848</BitOffs>
+            <BitOffs>644219392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -54333,19 +59202,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645254864</BitOffs>
+            <BitOffs>644219408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645269376</BitOffs>
+            <BitOffs>644233920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.bSTOEnable1</Name>
@@ -54358,7 +59227,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645567200</BitOffs>
+            <BitOffs>644531744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.bSTOEnable2</Name>
@@ -54370,7 +59239,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645567208</BitOffs>
+            <BitOffs>644531752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stYupEnc</Name>
@@ -54383,7 +59252,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645567232</BitOffs>
+            <BitOffs>644531776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stYdwnEnc</Name>
@@ -54395,7 +59264,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645567360</BitOffs>
+            <BitOffs>644531904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stXupEnc</Name>
@@ -54407,7 +59276,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645567488</BitOffs>
+            <BitOffs>644532032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stXdwnEnc</Name>
@@ -54419,7 +59288,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645567616</BitOffs>
+            <BitOffs>644532160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -54432,7 +59301,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645568192</BitOffs>
+            <BitOffs>644532736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -54445,7 +59314,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645568320</BitOffs>
+            <BitOffs>644532864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -54458,7 +59327,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645577664</BitOffs>
+            <BitOffs>644542208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -54471,7 +59340,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645577792</BitOffs>
+            <BitOffs>644542336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
@@ -54484,7 +59353,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645587936</BitOffs>
+            <BitOffs>644552480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.bSTOEnable2</Name>
@@ -54496,7 +59365,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645587944</BitOffs>
+            <BitOffs>644552488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stYupEnc</Name>
@@ -54509,7 +59378,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645587968</BitOffs>
+            <BitOffs>644552512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
@@ -54521,7 +59390,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645588096</BitOffs>
+            <BitOffs>644552640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stXupEnc</Name>
@@ -54533,7 +59402,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645588224</BitOffs>
+            <BitOffs>644552768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
@@ -54545,7 +59414,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645588352</BitOffs>
+            <BitOffs>644552896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -54558,7 +59427,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645588928</BitOffs>
+            <BitOffs>644553472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -54571,7 +59440,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645589056</BitOffs>
+            <BitOffs>644553600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -54584,7 +59453,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645598400</BitOffs>
+            <BitOffs>644562944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -54597,19 +59466,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645598528</BitOffs>
+            <BitOffs>644563072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645608768</BitOffs>
+            <BitOffs>644573312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
@@ -54632,7 +59501,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645616768</BitOffs>
+            <BitOffs>644581312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
@@ -54655,7 +59524,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645616776</BitOffs>
+            <BitOffs>644581320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bHome</Name>
@@ -54678,7 +59547,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645616784</BitOffs>
+            <BitOffs>644581328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bHardwareEnable</Name>
@@ -54701,7 +59570,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645616800</BitOffs>
+            <BitOffs>644581344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
@@ -54714,7 +59583,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645616832</BitOffs>
+            <BitOffs>644581376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
@@ -54727,7 +59596,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645616896</BitOffs>
+            <BitOffs>644581440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderINT</Name>
@@ -54740,19 +59609,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645616912</BitOffs>
+            <BitOffs>644581456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645630016</BitOffs>
+            <BitOffs>644594560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
@@ -54775,7 +59644,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645638016</BitOffs>
+            <BitOffs>644602560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
@@ -54798,7 +59667,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645638024</BitOffs>
+            <BitOffs>644602568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bHome</Name>
@@ -54821,7 +59690,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645638032</BitOffs>
+            <BitOffs>644602576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bHardwareEnable</Name>
@@ -54844,7 +59713,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645638048</BitOffs>
+            <BitOffs>644602592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
@@ -54857,7 +59726,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645638080</BitOffs>
+            <BitOffs>644602624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
@@ -54870,7 +59739,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645638144</BitOffs>
+            <BitOffs>644602688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderINT</Name>
@@ -54883,19 +59752,19 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645638160</BitOffs>
+            <BitOffs>644602704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647647552</BitOffs>
+            <BitOffs>646613440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gAmsNetIDEcatMaster1</Name>
@@ -54910,7 +59779,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434520</BitOffs>
+            <BitOffs>654431936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.nM1L3_RTD_1</Name>
@@ -54931,7 +59800,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655449760</BitOffs>
+            <BitOffs>654432032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.nM1L3_RTD_2</Name>
@@ -54950,7 +59819,46 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655449776</BitOffs>
+            <BitOffs>654432048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.nM1L3_RTD_3</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[EL3202-0010_MR1L3_2_3]^RTD Inputs Channel 2^Value</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>654447200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.nM2L3_RTD_1</Name>
+            <Comment> M2L3 RTDs</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[EL3202-0010_MR2L3_1]^RTD Inputs Channel 1^Value</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>654447216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3.MR1L3_Pitch.diEncCnt</Name>
@@ -54963,7 +59871,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655452352</BitOffs>
+            <BitOffs>654449792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4.MR1L4_Pitch.diEncCnt</Name>
@@ -54976,7 +59884,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655455104</BitOffs>
+            <BitOffs>654452544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3.MR2L3_Pitch.diEncCnt</Name>
@@ -54989,7 +59897,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655458112</BitOffs>
+            <BitOffs>654455552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.i_stCurrentBP</Name>
@@ -55005,7 +59913,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657398816</BitOffs>
+            <BitOffs>656396256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.xTxPDO_toggle</Name>
@@ -55026,7 +59934,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657402336</BitOffs>
+            <BitOffs>656399776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.xTxPDO_state</Name>
@@ -55047,46 +59955,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657402337</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_RTDS.nM1L3_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR1L3_2_3]^RTD Inputs Channel 2^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657536768</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_RTDS.nM2L3_RTD_1</Name>
-            <Comment> M2L3 RTDs</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR2L3_1]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>657536784</BitOffs>
+            <BitOffs>656399777</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.nM2L3_RTD_2</Name>
@@ -55105,7 +59974,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657536800</BitOffs>
+            <BitOffs>656534208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.nM2L3_RTD_3</Name>
@@ -55124,7 +59993,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657536816</BitOffs>
+            <BitOffs>656534224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.nM1L4_RTD_1</Name>
@@ -55144,7 +60013,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657536832</BitOffs>
+            <BitOffs>656534240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.nM1L4_RTD_2</Name>
@@ -55163,7 +60032,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657536848</BitOffs>
+            <BitOffs>656534256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.nM1L4_RTD_3</Name>
@@ -55182,14 +60051,14 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657536864</BitOffs>
+            <BitOffs>656534272</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">33</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -55200,7 +60069,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635015808</BitOffs>
+            <BitOffs>633977600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -55223,7 +60092,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635024856</BitOffs>
+            <BitOffs>633986648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55235,7 +60104,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635038464</BitOffs>
+            <BitOffs>634000256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -55247,7 +60116,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635336448</BitOffs>
+            <BitOffs>634298240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -55270,7 +60139,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635345496</BitOffs>
+            <BitOffs>634307288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55282,7 +60151,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635359104</BitOffs>
+            <BitOffs>634320896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -55294,7 +60163,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635657088</BitOffs>
+            <BitOffs>634618880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -55317,7 +60186,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635666136</BitOffs>
+            <BitOffs>634627928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55329,7 +60198,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635679744</BitOffs>
+            <BitOffs>634641536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -55341,7 +60210,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635977728</BitOffs>
+            <BitOffs>634939520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -55364,7 +60233,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635986776</BitOffs>
+            <BitOffs>634948568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55376,7 +60245,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636000384</BitOffs>
+            <BitOffs>634962176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -55388,7 +60257,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636298368</BitOffs>
+            <BitOffs>635260160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -55411,7 +60280,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636307416</BitOffs>
+            <BitOffs>635269208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55423,7 +60292,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636321024</BitOffs>
+            <BitOffs>635282816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -55435,7 +60304,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636619008</BitOffs>
+            <BitOffs>635580800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -55458,7 +60327,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636628056</BitOffs>
+            <BitOffs>635589848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55470,7 +60339,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636641664</BitOffs>
+            <BitOffs>635603456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.Axis.PlcToNc</Name>
@@ -55482,7 +60351,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636981056</BitOffs>
+            <BitOffs>635942848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bBrakeRelease</Name>
@@ -55505,7 +60374,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636990104</BitOffs>
+            <BitOffs>635951896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.Axis.PlcToNc</Name>
@@ -55517,7 +60386,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>637002304</BitOffs>
+            <BitOffs>635964096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bBrakeRelease</Name>
@@ -55540,7 +60409,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>637011352</BitOffs>
+            <BitOffs>635973144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55552,7 +60421,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639019840</BitOffs>
+            <BitOffs>637982976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -55564,7 +60433,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639329152</BitOffs>
+            <BitOffs>638292352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -55587,7 +60456,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639338200</BitOffs>
+            <BitOffs>638301400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m7.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55599,7 +60468,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639351808</BitOffs>
+            <BitOffs>638315008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -55611,7 +60480,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639649792</BitOffs>
+            <BitOffs>638612992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -55634,7 +60503,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639658840</BitOffs>
+            <BitOffs>638622040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m8.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55646,7 +60515,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639672448</BitOffs>
+            <BitOffs>638635648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -55658,7 +60527,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639970432</BitOffs>
+            <BitOffs>638933632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -55681,7 +60550,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639979480</BitOffs>
+            <BitOffs>638942680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m9.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55693,7 +60562,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639993088</BitOffs>
+            <BitOffs>638956288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -55705,7 +60574,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640291072</BitOffs>
+            <BitOffs>639254272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -55728,7 +60597,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640300120</BitOffs>
+            <BitOffs>639263320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m10.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55740,7 +60609,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640313728</BitOffs>
+            <BitOffs>639276928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -55752,7 +60621,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640611712</BitOffs>
+            <BitOffs>639574912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -55775,7 +60644,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640620760</BitOffs>
+            <BitOffs>639583960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m11.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55787,7 +60656,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640634368</BitOffs>
+            <BitOffs>639597568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -55799,7 +60668,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640932352</BitOffs>
+            <BitOffs>639895552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -55822,7 +60691,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640941400</BitOffs>
+            <BitOffs>639904600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55834,7 +60703,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640955008</BitOffs>
+            <BitOffs>639918208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.Axis.PlcToNc</Name>
@@ -55846,7 +60715,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641294400</BitOffs>
+            <BitOffs>640257600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bBrakeRelease</Name>
@@ -55869,7 +60738,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641303448</BitOffs>
+            <BitOffs>640266648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.Axis.PlcToNc</Name>
@@ -55881,7 +60750,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641315648</BitOffs>
+            <BitOffs>640278848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bBrakeRelease</Name>
@@ -55904,7 +60773,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641324696</BitOffs>
+            <BitOffs>640287896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55916,7 +60785,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643333184</BitOffs>
+            <BitOffs>642297728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -55928,7 +60797,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643642496</BitOffs>
+            <BitOffs>642607040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -55951,7 +60820,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643651544</BitOffs>
+            <BitOffs>642616088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -55963,7 +60832,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643665152</BitOffs>
+            <BitOffs>642629696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -55975,7 +60844,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643963136</BitOffs>
+            <BitOffs>642927680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -55998,7 +60867,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643972184</BitOffs>
+            <BitOffs>642936728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -56010,7 +60879,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643985792</BitOffs>
+            <BitOffs>642950336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -56022,7 +60891,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644283776</BitOffs>
+            <BitOffs>643248320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -56045,7 +60914,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644292824</BitOffs>
+            <BitOffs>643257368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -56057,7 +60926,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644306432</BitOffs>
+            <BitOffs>643270976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -56069,7 +60938,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644604416</BitOffs>
+            <BitOffs>643568960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -56092,7 +60961,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644613464</BitOffs>
+            <BitOffs>643578008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -56104,7 +60973,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644627072</BitOffs>
+            <BitOffs>643591616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -56116,7 +60985,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644925056</BitOffs>
+            <BitOffs>643889600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -56139,7 +61008,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644934104</BitOffs>
+            <BitOffs>643898648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -56151,7 +61020,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644947712</BitOffs>
+            <BitOffs>643912256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -56163,7 +61032,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645245696</BitOffs>
+            <BitOffs>644210240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -56186,7 +61055,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645254744</BitOffs>
+            <BitOffs>644219288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -56198,7 +61067,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645268352</BitOffs>
+            <BitOffs>644232896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.Axis.PlcToNc</Name>
@@ -56210,7 +61079,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645607744</BitOffs>
+            <BitOffs>644572288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bBrakeRelease</Name>
@@ -56233,7 +61102,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645616792</BitOffs>
+            <BitOffs>644581336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.Axis.PlcToNc</Name>
@@ -56245,7 +61114,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645628992</BitOffs>
+            <BitOffs>644593536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bBrakeRelease</Name>
@@ -56268,7 +61137,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645638040</BitOffs>
+            <BitOffs>644602584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -56280,7 +61149,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647646528</BitOffs>
+            <BitOffs>646612416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.bXRT_M2_OUT</Name>
@@ -56305,7 +61174,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434576</BitOffs>
+            <BitOffs>654431984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.bXRT_M2_IN</Name>
@@ -56329,7 +61198,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434584</BitOffs>
+            <BitOffs>654431992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut</Name>
@@ -56349,7 +61218,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655458440</BitOffs>
+            <BitOffs>654455880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2.q_xFastFaultOut</Name>
@@ -56369,7 +61238,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655953736</BitOffs>
+            <BitOffs>654951176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.q_stRequestedBP</Name>
@@ -56385,14 +61254,14 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657400576</BitOffs>
+            <BitOffs>656398016</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -56403,7 +61272,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096000</BitOffs>
+            <BitOffs>3072000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.bTrickleTripped</Name>
@@ -56423,7 +61292,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096040</BitOffs>
+            <BitOffs>3072040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GeneralConstants.MAX_STATES</Name>
@@ -56441,7 +61310,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096048</BitOffs>
+            <BitOffs>3072048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>DefaultGlobals.fTimeStamp</Name>
@@ -56452,7 +61321,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096064</BitOffs>
+            <BitOffs>3072064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.cLogHost</Name>
@@ -56483,7 +61352,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096128</BitOffs>
+            <BitOffs>3072128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.iLogPort</Name>
@@ -56505,7 +61374,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096256</BitOffs>
+            <BitOffs>3072256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
@@ -56519,7 +61388,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096272</BitOffs>
+            <BitOffs>3072272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
@@ -56534,7 +61403,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096328</BitOffs>
+            <BitOffs>3072328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
@@ -56549,7 +61418,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096336</BitOffs>
+            <BitOffs>3072336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nLocalTripThreshold</Name>
@@ -56564,7 +61433,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096352</BitOffs>
+            <BitOffs>3072352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
@@ -56579,7 +61448,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096384</BitOffs>
+            <BitOffs>3072384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nTrickleTripTime</Name>
@@ -56594,7 +61463,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096416</BitOffs>
+            <BitOffs>3072416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nTripResetPeriod</Name>
@@ -56609,7 +61478,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096448</BitOffs>
+            <BitOffs>3072448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.sPlcHostname</Name>
@@ -56623,7 +61492,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096480</BitOffs>
+            <BitOffs>3072480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
@@ -56638,7 +61507,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097128</BitOffs>
+            <BitOffs>3073128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_LOGGER</Name>
@@ -56653,7 +61522,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097136</BitOffs>
+            <BitOffs>3073136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -56675,7 +61544,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097152</BitOffs>
+            <BitOffs>3073152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nGlobAccEvents</Name>
@@ -56695,7 +61564,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097184</BitOffs>
+            <BitOffs>3073184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.fbRootLogger</Name>
@@ -56707,7 +61576,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097216</BitOffs>
+            <BitOffs>3073216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_EtherCAT</Name>
@@ -56747,7 +61616,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4179200</BitOffs>
+            <BitOffs>3155200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Standard</Name>
@@ -56787,7 +61656,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4179488</BitOffs>
+            <BitOffs>3155488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_System</Name>
@@ -56827,7 +61696,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4179776</BitOffs>
+            <BitOffs>3155776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
@@ -56842,7 +61711,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180064</BitOffs>
+            <BitOffs>3156064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_RTIME</Name>
@@ -56857,7 +61726,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180080</BitOffs>
+            <BitOffs>3156080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_IO</Name>
@@ -56872,7 +61741,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180096</BitOffs>
+            <BitOffs>3156096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NC</Name>
@@ -56886,7 +61755,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180112</BitOffs>
+            <BitOffs>3156112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSAF</Name>
@@ -56900,7 +61769,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180128</BitOffs>
+            <BitOffs>3156128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSVB</Name>
@@ -56914,7 +61783,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180144</BitOffs>
+            <BitOffs>3156144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_ISG</Name>
@@ -56928,7 +61797,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180160</BitOffs>
+            <BitOffs>3156160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CNC</Name>
@@ -56942,7 +61811,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180176</BitOffs>
+            <BitOffs>3156176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_LINE</Name>
@@ -56956,7 +61825,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180192</BitOffs>
+            <BitOffs>3156192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC</Name>
@@ -56970,7 +61839,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180208</BitOffs>
+            <BitOffs>3156208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS1</Name>
@@ -56985,7 +61854,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180224</BitOffs>
+            <BitOffs>3156224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS2</Name>
@@ -57000,7 +61869,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180240</BitOffs>
+            <BitOffs>3156240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS3</Name>
@@ -57015,7 +61884,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180256</BitOffs>
+            <BitOffs>3156256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS4</Name>
@@ -57030,7 +61899,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180272</BitOffs>
+            <BitOffs>3156272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAM</Name>
@@ -57044,7 +61913,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180288</BitOffs>
+            <BitOffs>3156288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAMTOOL</Name>
@@ -57059,7 +61928,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180304</BitOffs>
+            <BitOffs>3156304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
@@ -57074,7 +61943,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180320</BitOffs>
+            <BitOffs>3156320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -57089,7 +61958,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180336</BitOffs>
+            <BitOffs>3156336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INVALID</Name>
@@ -57104,7 +61973,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180352</BitOffs>
+            <BitOffs>3156352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_IDLE</Name>
@@ -57118,7 +61987,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180368</BitOffs>
+            <BitOffs>3156368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESET</Name>
@@ -57132,7 +62001,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180384</BitOffs>
+            <BitOffs>3156384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INIT</Name>
@@ -57146,7 +62015,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180400</BitOffs>
+            <BitOffs>3156400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_START</Name>
@@ -57160,7 +62029,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180416</BitOffs>
+            <BitOffs>3156416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RUN</Name>
@@ -57174,7 +62043,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180432</BitOffs>
+            <BitOffs>3156432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOP</Name>
@@ -57188,7 +62057,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180448</BitOffs>
+            <BitOffs>3156448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SAVECFG</Name>
@@ -57202,7 +62071,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180464</BitOffs>
+            <BitOffs>3156464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_LOADCFG</Name>
@@ -57216,7 +62085,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180480</BitOffs>
+            <BitOffs>3156480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERFAILURE</Name>
@@ -57230,7 +62099,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180496</BitOffs>
+            <BitOffs>3156496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERGOOD</Name>
@@ -57244,7 +62113,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180512</BitOffs>
+            <BitOffs>3156512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_ERROR</Name>
@@ -57258,7 +62127,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180528</BitOffs>
+            <BitOffs>3156528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SHUTDOWN</Name>
@@ -57272,7 +62141,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180544</BitOffs>
+            <BitOffs>3156544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SUSPEND</Name>
@@ -57286,7 +62155,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180560</BitOffs>
+            <BitOffs>3156560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESUME</Name>
@@ -57300,7 +62169,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180576</BitOffs>
+            <BitOffs>3156576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_CONFIG</Name>
@@ -57315,7 +62184,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180592</BitOffs>
+            <BitOffs>3156592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RECONFIG</Name>
@@ -57330,7 +62199,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180608</BitOffs>
+            <BitOffs>3156608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOPPING</Name>
@@ -57344,7 +62213,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180624</BitOffs>
+            <BitOffs>3156624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INCOMPATIBLE</Name>
@@ -57358,7 +62227,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180640</BitOffs>
+            <BitOffs>3156640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_EXCEPTION</Name>
@@ -57372,7 +62241,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180656</BitOffs>
+            <BitOffs>3156656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_MAXSTATES</Name>
@@ -57387,7 +62256,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180672</BitOffs>
+            <BitOffs>3156672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
@@ -57401,7 +62270,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180688</BitOffs>
+            <BitOffs>3156688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
@@ -57416,7 +62285,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180696</BitOffs>
+            <BitOffs>3156696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
@@ -57431,7 +62300,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180704</BitOffs>
+            <BitOffs>3156704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
@@ -57446,7 +62315,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180736</BitOffs>
+            <BitOffs>3156736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
@@ -57461,7 +62330,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180768</BitOffs>
+            <BitOffs>3156768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
@@ -57475,7 +62344,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180800</BitOffs>
+            <BitOffs>3156800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
@@ -57489,7 +62358,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180832</BitOffs>
+            <BitOffs>3156832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
@@ -57503,7 +62372,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180864</BitOffs>
+            <BitOffs>3156864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
@@ -57517,7 +62386,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180896</BitOffs>
+            <BitOffs>3156896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
@@ -57531,7 +62400,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180928</BitOffs>
+            <BitOffs>3156928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
@@ -57545,7 +62414,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180960</BitOffs>
+            <BitOffs>3156960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
@@ -57559,7 +62428,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180992</BitOffs>
+            <BitOffs>3156992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
@@ -57573,7 +62442,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181024</BitOffs>
+            <BitOffs>3157024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
@@ -57587,7 +62456,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181056</BitOffs>
+            <BitOffs>3157056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
@@ -57601,7 +62470,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181088</BitOffs>
+            <BitOffs>3157088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
@@ -57616,7 +62485,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181120</BitOffs>
+            <BitOffs>3157120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
@@ -57631,7 +62500,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181152</BitOffs>
+            <BitOffs>3157152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
@@ -57646,7 +62515,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181184</BitOffs>
+            <BitOffs>3157184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
@@ -57661,7 +62530,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181216</BitOffs>
+            <BitOffs>3157216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
@@ -57676,7 +62545,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181248</BitOffs>
+            <BitOffs>3157248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
@@ -57691,7 +62560,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181280</BitOffs>
+            <BitOffs>3157280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
@@ -57706,7 +62575,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181312</BitOffs>
+            <BitOffs>3157312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
@@ -57721,7 +62590,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181344</BitOffs>
+            <BitOffs>3157344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
@@ -57736,7 +62605,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181376</BitOffs>
+            <BitOffs>3157376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
@@ -57751,7 +62620,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181408</BitOffs>
+            <BitOffs>3157408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
@@ -57766,7 +62635,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181440</BitOffs>
+            <BitOffs>3157440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
@@ -57781,7 +62650,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181472</BitOffs>
+            <BitOffs>3157472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
@@ -57796,7 +62665,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181504</BitOffs>
+            <BitOffs>3157504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
@@ -57811,7 +62680,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181536</BitOffs>
+            <BitOffs>3157536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
@@ -57826,7 +62695,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181568</BitOffs>
+            <BitOffs>3157568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
@@ -57841,7 +62710,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181600</BitOffs>
+            <BitOffs>3157600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
@@ -57856,7 +62725,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181632</BitOffs>
+            <BitOffs>3157632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
@@ -57871,7 +62740,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181664</BitOffs>
+            <BitOffs>3157664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
@@ -57885,7 +62754,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181696</BitOffs>
+            <BitOffs>3157696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
@@ -57899,7 +62768,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181728</BitOffs>
+            <BitOffs>3157728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
@@ -57913,7 +62782,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181760</BitOffs>
+            <BitOffs>3157760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
@@ -57927,7 +62796,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181792</BitOffs>
+            <BitOffs>3157792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
@@ -57941,7 +62810,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181824</BitOffs>
+            <BitOffs>3157824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
@@ -57955,7 +62824,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181856</BitOffs>
+            <BitOffs>3157856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
@@ -57969,7 +62838,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181888</BitOffs>
+            <BitOffs>3157888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
@@ -57983,7 +62852,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181920</BitOffs>
+            <BitOffs>3157920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
@@ -57997,7 +62866,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181952</BitOffs>
+            <BitOffs>3157952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
@@ -58011,7 +62880,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181984</BitOffs>
+            <BitOffs>3157984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
@@ -58025,7 +62894,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182016</BitOffs>
+            <BitOffs>3158016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
@@ -58039,7 +62908,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182048</BitOffs>
+            <BitOffs>3158048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
@@ -58053,7 +62922,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182080</BitOffs>
+            <BitOffs>3158080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
@@ -58067,7 +62936,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182112</BitOffs>
+            <BitOffs>3158112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
@@ -58081,7 +62950,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182144</BitOffs>
+            <BitOffs>3158144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
@@ -58095,7 +62964,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182176</BitOffs>
+            <BitOffs>3158176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
@@ -58109,7 +62978,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182208</BitOffs>
+            <BitOffs>3158208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
@@ -58123,7 +62992,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182240</BitOffs>
+            <BitOffs>3158240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
@@ -58137,7 +63006,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182272</BitOffs>
+            <BitOffs>3158272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
@@ -58151,7 +63020,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182304</BitOffs>
+            <BitOffs>3158304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
@@ -58166,7 +63035,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182336</BitOffs>
+            <BitOffs>3158336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
@@ -58180,7 +63049,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182368</BitOffs>
+            <BitOffs>3158368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
@@ -58194,7 +63063,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182400</BitOffs>
+            <BitOffs>3158400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
@@ -58208,7 +63077,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182432</BitOffs>
+            <BitOffs>3158432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
@@ -58222,7 +63091,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182464</BitOffs>
+            <BitOffs>3158464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
@@ -58237,7 +63106,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182496</BitOffs>
+            <BitOffs>3158496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
@@ -58252,7 +63121,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182528</BitOffs>
+            <BitOffs>3158528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
@@ -58267,7 +63136,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182560</BitOffs>
+            <BitOffs>3158560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
@@ -58282,7 +63151,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182592</BitOffs>
+            <BitOffs>3158592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
@@ -58297,7 +63166,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182624</BitOffs>
+            <BitOffs>3158624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
@@ -58311,7 +63180,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182656</BitOffs>
+            <BitOffs>3158656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
@@ -58325,7 +63194,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182688</BitOffs>
+            <BitOffs>3158688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_INVALID</Name>
@@ -58340,7 +63209,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182720</BitOffs>
+            <BitOffs>3158720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_BSOD</Name>
@@ -58355,7 +63224,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182728</BitOffs>
+            <BitOffs>3158728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_RTVIOLATION</Name>
@@ -58370,7 +63239,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182736</BitOffs>
+            <BitOffs>3158736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.nWatchdogTime</Name>
@@ -58382,7 +63251,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182744</BitOffs>
+            <BitOffs>3158744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEREAD</Name>
@@ -58397,7 +63266,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182752</BitOffs>
+            <BitOffs>3158752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEWRITE</Name>
@@ -58412,7 +63281,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182784</BitOffs>
+            <BitOffs>3158784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
@@ -58427,7 +63296,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182816</BitOffs>
+            <BitOffs>3158816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEPLUS</Name>
@@ -58442,7 +63311,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182848</BitOffs>
+            <BitOffs>3158848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEBINARY</Name>
@@ -58457,7 +63326,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182880</BitOffs>
+            <BitOffs>3158880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODETEXT</Name>
@@ -58472,7 +63341,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182912</BitOffs>
+            <BitOffs>3158912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_PRIOCLASS</Name>
@@ -58487,7 +63356,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183168</BitOffs>
+            <BitOffs>3159168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_FMTSELF</Name>
@@ -58502,7 +63371,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183184</BitOffs>
+            <BitOffs>3159184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_LOG</Name>
@@ -58517,7 +63386,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183200</BitOffs>
+            <BitOffs>3159200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_MSGBOX</Name>
@@ -58532,7 +63401,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183216</BitOffs>
+            <BitOffs>3159216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_SRCID</Name>
@@ -58547,7 +63416,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183232</BitOffs>
+            <BitOffs>3159232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_AUTOFMTALL</Name>
@@ -58561,7 +63430,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183248</BitOffs>
+            <BitOffs>3159248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_INVALID</Name>
@@ -58576,7 +63445,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183264</BitOffs>
+            <BitOffs>3159264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_SIGNALED</Name>
@@ -58591,7 +63460,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183280</BitOffs>
+            <BitOffs>3159280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESET</Name>
@@ -58606,7 +63475,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183296</BitOffs>
+            <BitOffs>3159296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_CONFIRMED</Name>
@@ -58621,7 +63490,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183312</BitOffs>
+            <BitOffs>3159312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESETCON</Name>
@@ -58636,7 +63505,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183328</BitOffs>
+            <BitOffs>3159328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_SRCNAMESIZE</Name>
@@ -58650,7 +63519,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183344</BitOffs>
+            <BitOffs>3159344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_FMTPRGSIZE</Name>
@@ -58664,7 +63533,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183360</BitOffs>
+            <BitOffs>3159360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.eWatchdogConfig</Name>
@@ -58678,7 +63547,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183376</BitOffs>
+            <BitOffs>3159376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
@@ -58693,7 +63562,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183392</BitOffs>
+            <BitOffs>3159392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.PI</Name>
@@ -58707,7 +63576,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183424</BitOffs>
+            <BitOffs>3159424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_STRING_LENGTH</Name>
@@ -58722,7 +63591,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183488</BitOffs>
+            <BitOffs>3159488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_Module</Name>
@@ -58758,7 +63627,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184032</BitOffs>
+            <BitOffs>3160032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Utilities</Name>
@@ -58798,30 +63667,22 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184640</BitOffs>
+            <BitOffs>3160640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
             <Comment> Max. number of measures used in the profiler function block: 2..100 </Comment>
             <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <BaseType>INT (2..100)</BaseType>
             <Default>
               <Value>10</Value>
             </Default>
             <Properties>
               <Property>
-                <Name>LowerBorder</Name>
-                <Value>2</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>100</Value>
-              </Property>
-              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184928</BitOffs>
+            <BitOffs>3160928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_SBCS_TABLE</Name>
@@ -58836,7 +63697,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184960</BitOffs>
+            <BitOffs>3160960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
@@ -58851,7 +63712,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184976</BitOffs>
+            <BitOffs>3160976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_SEP</Name>
@@ -58866,7 +63727,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184984</BitOffs>
+            <BitOffs>3160984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
@@ -58881,7 +63742,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184992</BitOffs>
+            <BitOffs>3160992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
@@ -58896,7 +63757,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246496</BitOffs>
+            <BitOffs>3222496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
@@ -58911,7 +63772,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246528</BitOffs>
+            <BitOffs>3222528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
@@ -58926,7 +63787,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246560</BitOffs>
+            <BitOffs>3222560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
@@ -58941,7 +63802,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246592</BitOffs>
+            <BitOffs>3222592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
@@ -58956,7 +63817,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246624</BitOffs>
+            <BitOffs>3222624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
@@ -58971,7 +63832,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246656</BitOffs>
+            <BitOffs>3222656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
@@ -58986,7 +63847,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246688</BitOffs>
+            <BitOffs>3222688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
@@ -59001,7 +63862,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246720</BitOffs>
+            <BitOffs>3222720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
@@ -59016,7 +63877,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246752</BitOffs>
+            <BitOffs>3222752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
@@ -59031,7 +63892,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246784</BitOffs>
+            <BitOffs>3222784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
@@ -59046,7 +63907,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246816</BitOffs>
+            <BitOffs>3222816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_REMOTE_PCS</Name>
@@ -59061,7 +63922,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246848</BitOffs>
+            <BitOffs>3222848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_NAME_LEN</Name>
@@ -59076,7 +63937,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246864</BitOffs>
+            <BitOffs>3222864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_ADDR_LEN</Name>
@@ -59091,7 +63952,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246872</BitOffs>
+            <BitOffs>3222872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
@@ -59106,7 +63967,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246880</BitOffs>
+            <BitOffs>3222880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
@@ -59121,7 +63982,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246912</BitOffs>
+            <BitOffs>3222912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
@@ -59136,7 +63997,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246944</BitOffs>
+            <BitOffs>3222944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MIN_ROUTE_TRANSPORT</Name>
@@ -59151,7 +64012,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246976</BitOffs>
+            <BitOffs>3222976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_TRANSPORT</Name>
@@ -59166,7 +64027,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246984</BitOffs>
+            <BitOffs>3222984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_AMSLOGGER</Name>
@@ -59181,7 +64042,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246992</BitOffs>
+            <BitOffs>3222992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ROUTE_ENTRY</Name>
@@ -59215,7 +64076,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4247008</BitOffs>
+            <BitOffs>3223008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FFILEFIND</Name>
@@ -59230,7 +64091,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248192</BitOffs>
+            <BitOffs>3224192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.HKEY_MAX_BINARY_DATA_SIZE</Name>
@@ -59245,7 +64106,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248224</BitOffs>
+            <BitOffs>3224224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IGR_GENERAL</Name>
@@ -59260,7 +64121,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248256</BitOffs>
+            <BitOffs>3224256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IOF_MODE</Name>
@@ -59275,7 +64136,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248288</BitOffs>
+            <BitOffs>3224288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_TYPEFIELDVALUE</Name>
@@ -59290,7 +64151,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248672</BitOffs>
+            <BitOffs>3224672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INVALIDPOINTERINPUT</Name>
@@ -59305,7 +64166,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248832</BitOffs>
+            <BitOffs>3224832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ARG_VALUE</Name>
@@ -59331,7 +64192,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248864</BitOffs>
+            <BitOffs>3224864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_DECASC_CODES</Name>
@@ -59389,7 +64250,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4249216</BitOffs>
+            <BitOffs>3225216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_MONTHDAYS</Name>
@@ -59506,7 +64367,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4254704</BitOffs>
+            <BitOffs>3230704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_YEARSDAY</Name>
@@ -59639,7 +64500,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255088</BitOffs>
+            <BitOffs>3231088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
@@ -59654,7 +64515,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255552</BitOffs>
+            <BitOffs>3231552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC</Name>
@@ -59676,7 +64537,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255584</BitOffs>
+            <BitOffs>3231584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC</Name>
@@ -59698,7 +64559,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255648</BitOffs>
+            <BitOffs>3231648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY</Name>
@@ -59720,7 +64581,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255712</BitOffs>
+            <BitOffs>3231712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN</Name>
@@ -59742,7 +64603,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255776</BitOffs>
+            <BitOffs>3231776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX</Name>
@@ -59764,7 +64625,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255840</BitOffs>
+            <BitOffs>3231840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC64</Name>
@@ -59779,7 +64640,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255936</BitOffs>
+            <BitOffs>3231936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC64</Name>
@@ -59794,7 +64655,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256000</BitOffs>
+            <BitOffs>3232000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY64</Name>
@@ -59809,7 +64670,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256064</BitOffs>
+            <BitOffs>3232064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN64</Name>
@@ -59824,7 +64685,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256128</BitOffs>
+            <BitOffs>3232128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX64</Name>
@@ -59839,7 +64700,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256192</BitOffs>
+            <BitOffs>3232192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.WEST_EUROPE_TZI</Name>
@@ -59912,7 +64773,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256256</BitOffs>
+            <BitOffs>3232256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
@@ -59927,7 +64788,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4261216</BitOffs>
+            <BitOffs>3237216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERWEEK</Name>
@@ -59942,7 +64803,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4261248</BitOffs>
+            <BitOffs>3237248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_NONE</Name>
@@ -59957,7 +64818,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267456</BitOffs>
+            <BitOffs>3243456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_LOG</Name>
@@ -59972,7 +64833,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267488</BitOffs>
+            <BitOffs>3243488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_FILE</Name>
@@ -59987,7 +64848,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267520</BitOffs>
+            <BitOffs>3243520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_VISU</Name>
@@ -60002,7 +64863,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267552</BitOffs>
+            <BitOffs>3243552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
@@ -60017,7 +64878,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4384720</BitOffs>
+            <BitOffs>3360720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_CR</Name>
@@ -60032,7 +64893,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4384728</BitOffs>
+            <BitOffs>3360728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_LF</Name>
@@ -60047,7 +64908,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4384736</BitOffs>
+            <BitOffs>3360736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRUCT</Name>
@@ -60104,7 +64965,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4386464</BitOffs>
+            <BitOffs>3362464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRING</Name>
@@ -60118,7 +64979,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4386592</BitOffs>
+            <BitOffs>3362592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_REGSTRING</Name>
@@ -60132,7 +64993,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4386888</BitOffs>
+            <BitOffs>3362888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ASCII_STX</Name>
@@ -60146,7 +65007,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387224</BitOffs>
+            <BitOffs>3363224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_IoFunctions</Name>
@@ -60186,7 +65047,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387328</BitOffs>
+            <BitOffs>3363328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ModbusSrv</Name>
@@ -60222,7 +65083,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387616</BitOffs>
+            <BitOffs>3363616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_SerialCom</Name>
@@ -60262,7 +65123,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387904</BitOffs>
+            <BitOffs>3363904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_COMPORT</Name>
@@ -60278,7 +65139,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388192</BitOffs>
+            <BitOffs>3364192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_CMD</Name>
@@ -60292,7 +65153,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388224</BitOffs>
+            <BitOffs>3364224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_DATAPOINTER</Name>
@@ -60306,7 +65167,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388256</BitOffs>
+            <BitOffs>3364256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_CFGSTLEN</Name>
@@ -60320,7 +65181,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388288</BitOffs>
+            <BitOffs>3364288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_CFGSTVER</Name>
@@ -60335,7 +65196,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388320</BitOffs>
+            <BitOffs>3364320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_TL</Name>
@@ -60350,7 +65211,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388352</BitOffs>
+            <BitOffs>3364352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_BAUDRATE</Name>
@@ -60364,7 +65225,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388384</BitOffs>
+            <BitOffs>3364384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_PARITY</Name>
@@ -60378,7 +65239,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388416</BitOffs>
+            <BitOffs>3364416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_DATABITS</Name>
@@ -60392,7 +65253,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388448</BitOffs>
+            <BitOffs>3364448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_STOPBITS</Name>
@@ -60406,7 +65267,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388480</BitOffs>
+            <BitOffs>3364480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_DTR_CTRL</Name>
@@ -60420,7 +65281,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388512</BitOffs>
+            <BitOffs>3364512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_RTS_CTRL</Name>
@@ -60434,7 +65295,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388544</BitOffs>
+            <BitOffs>3364544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_CTS_OUTCTRL</Name>
@@ -60448,7 +65309,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388576</BitOffs>
+            <BitOffs>3364576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_DSR_OUTCTRL</Name>
@@ -60462,7 +65323,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388608</BitOffs>
+            <BitOffs>3364608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_INVALID_DSR_SENS</Name>
@@ -60476,7 +65337,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388640</BitOffs>
+            <BitOffs>3364640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_NOT_INIT</Name>
@@ -60491,7 +65352,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388672</BitOffs>
+            <BitOffs>3364672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_RD_BUFFER_OVERRUN</Name>
@@ -60505,7 +65366,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388704</BitOffs>
+            <BitOffs>3364704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_PORT_CONNECTED</Name>
@@ -60520,7 +65381,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388736</BitOffs>
+            <BitOffs>3364736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_PORT_NOT_CONNECTED</Name>
@@ -60535,7 +65396,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388768</BitOffs>
+            <BitOffs>3364768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_RD_THREAD_TIMEOUT</Name>
@@ -60549,7 +65410,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388800</BitOffs>
+            <BitOffs>3364800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_WR_THREAD_TIMEOUT</Name>
@@ -60563,7 +65424,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388832</BitOffs>
+            <BitOffs>3364832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_RD_FAILURE</Name>
@@ -60577,7 +65438,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388864</BitOffs>
+            <BitOffs>3364864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_WR_FAILURE</Name>
@@ -60591,7 +65452,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388896</BitOffs>
+            <BitOffs>3364896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.COMERRORADS_SERVER_INCOMPATIBLE</Name>
@@ -60606,7 +65467,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388928</BitOffs>
+            <BitOffs>3364928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ASCII_ETX</Name>
@@ -60620,7 +65481,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389464</BitOffs>
+            <BitOffs>3365464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ASCII_DLE</Name>
@@ -60634,7 +65495,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389472</BitOffs>
+            <BitOffs>3365472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ASCII_NAK</Name>
@@ -60648,7 +65509,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389480</BitOffs>
+            <BitOffs>3365480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_RETRIES</Name>
@@ -60662,7 +65523,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389488</BitOffs>
+            <BitOffs>3365488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMEOUT_ZVZ</Name>
@@ -60677,7 +65538,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389504</BitOffs>
+            <BitOffs>3365504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMEOUT_QVZ</Name>
@@ -60692,7 +65553,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389536</BitOffs>
+            <BitOffs>3365536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMEOUT_WVZ</Name>
@@ -60707,7 +65568,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389568</BitOffs>
+            <BitOffs>3365568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_CLASS</Name>
@@ -60764,7 +65625,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389600</BitOffs>
+            <BitOffs>3365600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_ID</Name>
@@ -60778,7 +65639,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389728</BitOffs>
+            <BitOffs>3365728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_SEVERITY</Name>
@@ -60792,7 +65653,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389760</BitOffs>
+            <BitOffs>3365760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_TCPIPSRV</Name>
@@ -60806,7 +65667,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389776</BitOffs>
+            <BitOffs>3365776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.SUCCESS_EVENT</Name>
@@ -60871,7 +65732,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389792</BitOffs>
+            <BitOffs>3365792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.nLangId_OnlineMonitoring</Name>
@@ -60886,30 +65747,22 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389984</BitOffs>
+            <BitOffs>3365984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>ParameterList.cSourceNameSize</Name>
             <Comment> size [bytes] for source names (recommended is a size between 128 and 512)</Comment>
             <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
+            <BaseType>UDINT (81..10000)</BaseType>
             <Default>
               <Value>256</Value>
             </Default>
             <Properties>
               <Property>
-                <Name>LowerBorder</Name>
-                <Value>81</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>10000</Value>
-              </Property>
-              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390016</BitOffs>
+            <BitOffs>3366016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_EventLogger</Name>
@@ -60949,7 +65802,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390048</BitOffs>
+            <BitOffs>3366048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_INTERNAL.UNINITIALIZED_CLASS_GUID</Name>
@@ -61007,7 +65860,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390336</BitOffs>
+            <BitOffs>3366336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -61021,7 +65874,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390464</BitOffs>
+            <BitOffs>3366464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_CONLIST</Name>
@@ -61035,7 +65888,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390496</BitOffs>
+            <BitOffs>3366496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_CLOSEBYHDL</Name>
@@ -61049,7 +65902,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390528</BitOffs>
+            <BitOffs>3366528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_SENDBYHDL</Name>
@@ -61063,7 +65916,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390560</BitOffs>
+            <BitOffs>3366560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_PEERBYHDL</Name>
@@ -61077,7 +65930,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390592</BitOffs>
+            <BitOffs>3366592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_RECVBYHDL</Name>
@@ -61091,7 +65944,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390624</BitOffs>
+            <BitOffs>3366624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_RECVFROMBYHDL</Name>
@@ -61105,7 +65958,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390656</BitOffs>
+            <BitOffs>3366656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_SENDTOBYHDL</Name>
@@ -61119,7 +65972,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390688</BitOffs>
+            <BitOffs>3366688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_MULTICAST_ADDBYHDL</Name>
@@ -61133,7 +65986,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390720</BitOffs>
+            <BitOffs>3366720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_MULTICAST_DROPBYHDL</Name>
@@ -61147,7 +66000,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390752</BitOffs>
+            <BitOffs>3366752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_IGR_ADAPTER_LINKSTATUS</Name>
@@ -61161,7 +66014,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390784</BitOffs>
+            <BitOffs>3366784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADSCONLST_IOF_CONNECT</Name>
@@ -61175,7 +66028,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390816</BitOffs>
+            <BitOffs>3366816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADSCONLST_IOF_LISTEN</Name>
@@ -61189,7 +66042,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390848</BitOffs>
+            <BitOffs>3366848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADSCONLST_IOF_CLOSEALL</Name>
@@ -61203,7 +66056,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390880</BitOffs>
+            <BitOffs>3366880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADSCONLST_IOF_ACCEPT</Name>
@@ -61217,7 +66070,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390912</BitOffs>
+            <BitOffs>3366912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADSCONLST_IOF_UDPBIND</Name>
@@ -61231,7 +66084,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390944</BitOffs>
+            <BitOffs>3366944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADSCONLST_IOF_GETHNDLBYADDR</Name>
@@ -61245,7 +66098,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390976</BitOffs>
+            <BitOffs>3366976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADSCONLST_IOF_GETLINKSTATUS</Name>
@@ -61259,7 +66112,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391008</BitOffs>
+            <BitOffs>3367008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCPADS_NULL_HSOCKET</Name>
@@ -61293,7 +66146,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391040</BitOffs>
+            <BitOffs>3367040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.LISTEN_MODE_CLOSEALL</Name>
@@ -61308,7 +66161,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391392</BitOffs>
+            <BitOffs>3367392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.LISTEN_MODE_USEOPENED</Name>
@@ -61323,7 +66176,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391424</BitOffs>
+            <BitOffs>3367424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.CONNECT_MODE_ENABLEDBG</Name>
@@ -61338,7 +66191,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391456</BitOffs>
+            <BitOffs>3367456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_THROTTLE_MODE</Name>
@@ -61352,7 +66205,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391488</BitOffs>
+            <BitOffs>3367488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.THROTTLE_MODE_OFF</Name>
@@ -61417,7 +66270,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391520</BitOffs>
+            <BitOffs>3367520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.THROTTLE_MODE_DEFAULT</Name>
@@ -61482,7 +66335,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391936</BitOffs>
+            <BitOffs>3367936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_JsonXml</Name>
@@ -61522,7 +66375,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392352</BitOffs>
+            <BitOffs>3368352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
@@ -61536,7 +66389,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392640</BitOffs>
+            <BitOffs>3368640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -61550,7 +66403,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392656</BitOffs>
+            <BitOffs>3368656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -61564,7 +66417,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392672</BitOffs>
+            <BitOffs>3368672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
@@ -61591,7 +66444,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392688</BitOffs>
+            <BitOffs>3368688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -61606,7 +66459,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392696</BitOffs>
+            <BitOffs>3368696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
@@ -61621,7 +66474,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392704</BitOffs>
+            <BitOffs>3368704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
@@ -61636,7 +66489,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4392736</BitOffs>
+            <BitOffs>3368736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -61654,7 +66507,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394784</BitOffs>
+            <BitOffs>3370784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -61666,7 +66519,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394800</BitOffs>
+            <BitOffs>3370800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
@@ -61678,7 +66531,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394808</BitOffs>
+            <BitOffs>3370808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -61694,7 +66547,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394816</BitOffs>
+            <BitOffs>3370816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
@@ -61705,7 +66558,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394848</BitOffs>
+            <BitOffs>3370848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
@@ -61717,7 +66570,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626222048</BitOffs>
+            <BitOffs>625198048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
@@ -61729,7 +66582,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626222080</BitOffs>
+            <BitOffs>625198080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -61743,13 +66596,13 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626224128</BitOffs>
+            <BitOffs>625200128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.bMR1L3PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>626224136</BitOffs>
+            <BitOffs>625200136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -61765,7 +66618,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626224144</BitOffs>
+            <BitOffs>625200144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -61780,7 +66633,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626224160</BitOffs>
+            <BitOffs>625200160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -61788,25 +66641,17 @@ Beckhoff</Comment>
        We do this by defining an array, in where we can see which current TEST_ORDERED() is the one to be handled right now.
        The below array is only used for TEST_ORDERED()-tests.  </Comment>
             <BitSize>16000</BitSize>
-            <BaseType>UINT</BaseType>
+            <BaseType>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
               <Elements>1000</Elements>
             </ArrayInfo>
             <Properties>
               <Property>
-                <Name>LowerBorder</Name>
-                <Value>1</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>100</Value>
-              </Property>
-              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626256160</BitOffs>
+            <BitOffs>625232160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -61818,7 +66663,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626272160</BitOffs>
+            <BitOffs>625248160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -61854,7 +66699,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634593024</BitOffs>
+            <BitOffs>633569024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.MAX_STATES</Name>
@@ -61870,7 +66715,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634593312</BitOffs>
+            <BitOffs>633569312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
@@ -61885,7 +66730,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634593328</BitOffs>
+            <BitOffs>633569328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.stUnknownState</Name>
@@ -61902,7 +66747,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634593344</BitOffs>
+            <BitOffs>633569344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.stInvalidState</Name>
@@ -61913,7 +66758,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634596288</BitOffs>
+            <BitOffs>633572288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
@@ -61933,7 +66778,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634599232</BitOffs>
+            <BitOffs>633575232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -61953,7 +66798,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634600992</BitOffs>
+            <BitOffs>633576992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -61978,7 +66823,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634602752</BitOffs>
+            <BitOffs>633578752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -61990,7 +66835,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634603776</BitOffs>
+            <BitOffs>633579776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -62005,35 +66850,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634603808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634603840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634603904</BitOffs>
+            <BitOffs>633579904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -62047,7 +66864,35 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634603968</BitOffs>
+            <BitOffs>633579936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633579968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633580032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -62062,7 +66907,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634604000</BitOffs>
+            <BitOffs>633580096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -62076,7 +66921,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634604032</BitOffs>
+            <BitOffs>633580128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -62101,7 +66946,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634604048</BitOffs>
+            <BitOffs>633580144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stAttenuators</Name>
@@ -62122,7 +66967,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634604064</BitOffs>
+            <BitOffs>633580160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cstFullBeam</Name>
@@ -62142,7 +66987,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634604128</BitOffs>
+            <BitOffs>633580224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cst0RateBeam</Name>
@@ -62162,7 +67007,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634605888</BitOffs>
+            <BitOffs>633581984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -62177,7 +67022,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607648</BitOffs>
+            <BitOffs>633583744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_cBoundaries</Name>
@@ -62191,7 +67036,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607664</BitOffs>
+            <BitOffs>633583760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -62210,7 +67055,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634607680</BitOffs>
+            <BitOffs>633583776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -62237,7 +67082,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634608704</BitOffs>
+            <BitOffs>633584800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -62392,7 +67237,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634608736</BitOffs>
+            <BitOffs>633584832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -62547,7 +67392,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634609760</BitOffs>
+            <BitOffs>633585856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
@@ -62562,7 +67407,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610784</BitOffs>
+            <BitOffs>633586880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.nCTRL_LOGGER_DATA_ARRAY_SIZE</Name>
@@ -62576,7 +67421,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610800</BitOffs>
+            <BitOffs>633586896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -62591,7 +67436,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610816</BitOffs>
+            <BitOffs>633586912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -62606,7 +67451,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610848</BitOffs>
+            <BitOffs>633586944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -62617,7 +67462,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634610880</BitOffs>
+            <BitOffs>633586976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -62657,7 +67502,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634611136</BitOffs>
+            <BitOffs>633587232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -62668,22 +67513,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634611424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoRange</Name>
-            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>60</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634618400</BitOffs>
+            <BitOffs>633587520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -62697,7 +67527,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634618432</BitOffs>
+            <BitOffs>633594496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -62711,7 +67541,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634618496</BitOffs>
+            <BitOffs>633594560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -62747,7 +67577,22 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634618560</BitOffs>
+            <BitOffs>633594624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoRange</Name>
+            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>60</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633594912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
@@ -62762,7 +67607,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634618880</BitOffs>
+            <BitOffs>633594944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMaxVoltage</Name>
@@ -62777,7 +67622,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634618944</BitOffs>
+            <BitOffs>633595008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMinVoltage</Name>
@@ -62792,7 +67637,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634619008</BitOffs>
+            <BitOffs>633595072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
@@ -62821,7 +67666,47 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634619072</BitOffs>
+            <BitOffs>633595136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>6</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>0.6.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633597632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.stCtrl_GLOBAL_CycleTimeInterpretation</Name>
@@ -62832,13 +67717,13 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634621568</BitOffs>
+            <BitOffs>633597952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams_MR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>634792448</BitOffs>
+            <BitOffs>633743072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_MR1L3</Name>
@@ -62851,13 +67736,13 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>634792512</BitOffs>
+            <BitOffs>633743136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams_MR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>634896768</BitOffs>
+            <BitOffs>633852992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_MR2L3</Name>
@@ -62870,13 +67755,13 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>634896832</BitOffs>
+            <BitOffs>633853056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams_MR2L4</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>635001088</BitOffs>
+            <BitOffs>633962912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_MR2L4</Name>
@@ -62889,13 +67774,13 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>635001152</BitOffs>
+            <BitOffs>633962976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>635001376</BitOffs>
+            <BitOffs>633963200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRstM1</Name>
@@ -62908,7 +67793,7 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>635001440</BitOffs>
+            <BitOffs>633963264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRstM2</Name>
@@ -62921,7 +67806,7 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>635001664</BitOffs>
+            <BitOffs>633963488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.tpImAPLC</Name>
@@ -62933,31 +67818,7 @@ Beckhoff</Comment>
                 <Value>10000</Value>
               </SubItem>
             </Default>
-            <BitOffs>635015520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR1L3PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>635015712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR1L4PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>635015720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR1L4PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>635015728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR2L3PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>635015736</BitOffs>
+            <BitOffs>633977344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -62998,13 +67859,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635015744</BitOffs>
+            <BitOffs>633977536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635036992</BitOffs>
+            <BitOffs>633998784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -63037,13 +67898,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635336384</BitOffs>
+            <BitOffs>634298176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635357632</BitOffs>
+            <BitOffs>634319424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -63077,13 +67938,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635657024</BitOffs>
+            <BitOffs>634618816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635678272</BitOffs>
+            <BitOffs>634640064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -63116,13 +67977,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635977664</BitOffs>
+            <BitOffs>634939456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635998912</BitOffs>
+            <BitOffs>634960704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -63157,13 +68018,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>636298304</BitOffs>
+            <BitOffs>635260096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m5</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636319552</BitOffs>
+            <BitOffs>635281344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -63198,13 +68059,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>636618944</BitOffs>
+            <BitOffs>635580736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636640192</BitOffs>
+            <BitOffs>635601984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3</Name>
@@ -63227,7 +68088,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>636939584</BitOffs>
+            <BitOffs>635901376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats</Name>
@@ -63241,7 +68102,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>636960256</BitOffs>
+            <BitOffs>635922048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbYRMSErrorMR1L3</Name>
@@ -63256,19 +68117,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>637410752</BitOffs>
+            <BitOffs>636372544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>637797632</BitOffs>
+            <BitOffs>636759424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinYRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>637797696</BitOffs>
+            <BitOffs>636759488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbXRMSErrorMR1L3</Name>
@@ -63282,19 +68143,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>637797760</BitOffs>
+            <BitOffs>636759552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638184640</BitOffs>
+            <BitOffs>637146432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinXRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638184704</BitOffs>
+            <BitOffs>637146496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbPitchRMSErrorMR1L3</Name>
@@ -63308,19 +68169,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638184768</BitOffs>
+            <BitOffs>637146560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPitchRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638571648</BitOffs>
+            <BitOffs>637533440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinPitchRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638571712</BitOffs>
+            <BitOffs>637533504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderRMSErrorMR1L3</Name>
@@ -63334,33 +68195,57 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638571776</BitOffs>
+            <BitOffs>637533568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBenderRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638958656</BitOffs>
+            <BitOffs>637920448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinBenderRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638958720</BitOffs>
+            <BitOffs>637920512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3PitchControl</Name>
             <Comment> Pitch Control</Comment>
-            <BitSize>365504</BitSize>
+            <BitSize>366848</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>638958784</BitOffs>
+            <BitOffs>637920576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR1L3PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>638287424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR1L4PitchDone</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>638287432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR1L4PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>638287440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR2L3PitchDone</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>638287448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderMR1L3</Name>
             <Comment> Bender Control</Comment>
             <BitSize>128</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
-            <BitOffs>639324288</BitOffs>
+            <BitOffs>638287456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYupMR1L3</Name>
@@ -63377,7 +68262,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324416</BitOffs>
+            <BitOffs>638287584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYdwnMR1L3</Name>
@@ -63393,7 +68278,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324448</BitOffs>
+            <BitOffs>638287616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXupMR1L3</Name>
@@ -63409,7 +68294,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324480</BitOffs>
+            <BitOffs>638287648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXdwnMR1L3</Name>
@@ -63425,7 +68310,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324512</BitOffs>
+            <BitOffs>638287680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntPitchMR1L3</Name>
@@ -63441,7 +68326,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324544</BitOffs>
+            <BitOffs>638287712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYupMR1L3</Name>
@@ -63458,7 +68343,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324576</BitOffs>
+            <BitOffs>638287744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYdwnMR1L3</Name>
@@ -63474,7 +68359,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324608</BitOffs>
+            <BitOffs>638287776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXupMR1L3</Name>
@@ -63490,7 +68375,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324640</BitOffs>
+            <BitOffs>638287808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXdwnMR1L3</Name>
@@ -63506,7 +68391,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324672</BitOffs>
+            <BitOffs>638287840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefPitchMR1L3</Name>
@@ -63522,20 +68407,37 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639324704</BitOffs>
+            <BitOffs>638287872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.nEncCntYupMR1L4</Name>
+            <Comment> Raw Encoder Counts</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1L4:HOMS:ENC:YUP:CNT
+        field: EGU cnt
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>638287904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.mcReadParameterPitchMR1L3</Name>
             <BitSize>4288</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>639324736</BitOffs>
+            <BitOffs>638287936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fEncRefPitchMR1L3_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>639329024</BitOffs>
+            <BitOffs>638292224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -63571,13 +68473,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639329088</BitOffs>
+            <BitOffs>638292288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m7</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>639350336</BitOffs>
+            <BitOffs>638313536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -63610,13 +68512,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639649728</BitOffs>
+            <BitOffs>638612928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m8</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>639670976</BitOffs>
+            <BitOffs>638634176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -63650,13 +68552,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639970368</BitOffs>
+            <BitOffs>638933568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m9</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>639991616</BitOffs>
+            <BitOffs>638954816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -63689,13 +68591,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>640291008</BitOffs>
+            <BitOffs>639254208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m10</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>640312256</BitOffs>
+            <BitOffs>639275456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -63730,13 +68632,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>640611648</BitOffs>
+            <BitOffs>639574848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m11</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>640632896</BitOffs>
+            <BitOffs>639596096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -63771,13 +68673,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>640932288</BitOffs>
+            <BitOffs>639895488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>640953536</BitOffs>
+            <BitOffs>639916736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4</Name>
@@ -63800,7 +68702,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>641252928</BitOffs>
+            <BitOffs>640216128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats</Name>
@@ -63814,7 +68716,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>641273600</BitOffs>
+            <BitOffs>640236800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbYRMSErrorMR1L4</Name>
@@ -63829,19 +68731,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>641724096</BitOffs>
+            <BitOffs>640687296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642110976</BitOffs>
+            <BitOffs>641074176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinYRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642111040</BitOffs>
+            <BitOffs>641074240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbXRMSErrorMR1L4</Name>
@@ -63855,19 +68757,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642111104</BitOffs>
+            <BitOffs>641074304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642497984</BitOffs>
+            <BitOffs>641461184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinXRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642498048</BitOffs>
+            <BitOffs>641461248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbPitchRMSErrorMR1L4</Name>
@@ -63881,19 +68783,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642498112</BitOffs>
+            <BitOffs>641461312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPitchRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642884992</BitOffs>
+            <BitOffs>641848192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinPitchRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642885056</BitOffs>
+            <BitOffs>641848256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderRMSErrorMR1L4</Name>
@@ -63907,50 +68809,33 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642885120</BitOffs>
+            <BitOffs>641848320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBenderRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>643272000</BitOffs>
+            <BitOffs>642235200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinBenderRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>643272064</BitOffs>
+            <BitOffs>642235264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4PitchControl</Name>
             <Comment> Pitch Control</Comment>
-            <BitSize>365504</BitSize>
+            <BitSize>366848</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>643272128</BitOffs>
+            <BitOffs>642235328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderMR1L4</Name>
             <Comment> Bender Control</Comment>
             <BitSize>128</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
-            <BitOffs>643637632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.nEncCntYupMR1L4</Name>
-            <Comment> Raw Encoder Counts</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1L4:HOMS:ENC:YUP:CNT
-        field: EGU cnt
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>643637760</BitOffs>
+            <BitOffs>642602176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYdwnMR1L4</Name>
@@ -63966,7 +68851,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643637792</BitOffs>
+            <BitOffs>642602304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXupMR1L4</Name>
@@ -63982,7 +68867,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643637824</BitOffs>
+            <BitOffs>642602336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXdwnMR1L4</Name>
@@ -63998,7 +68883,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643637856</BitOffs>
+            <BitOffs>642602368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntPitchMR1L4</Name>
@@ -64014,7 +68899,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643637888</BitOffs>
+            <BitOffs>642602400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYupMR1L4</Name>
@@ -64031,7 +68916,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643637920</BitOffs>
+            <BitOffs>642602432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYdwnMR1L4</Name>
@@ -64047,7 +68932,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643637952</BitOffs>
+            <BitOffs>642602464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXupMR1L4</Name>
@@ -64063,7 +68948,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643637984</BitOffs>
+            <BitOffs>642602496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXdwnMR1L4</Name>
@@ -64079,7 +68964,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643638016</BitOffs>
+            <BitOffs>642602528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefPitchMR1L4</Name>
@@ -64095,20 +68980,44 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643638048</BitOffs>
+            <BitOffs>642602560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR2L3PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>642602592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PMPS.bMR1L3_OUT_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>642602600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PMPS.bRemove</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>642602608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PMPS.bExist</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>642602616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.mcReadParameterPitchMR1L4</Name>
             <BitSize>4288</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>643638080</BitOffs>
+            <BitOffs>642602624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fEncRefPitchMR1L4_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>643642368</BitOffs>
+            <BitOffs>642606912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -64142,13 +69051,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643642432</BitOffs>
+            <BitOffs>642606976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>643663680</BitOffs>
+            <BitOffs>642628224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -64182,13 +69091,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643963072</BitOffs>
+            <BitOffs>642927616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>643984320</BitOffs>
+            <BitOffs>642948864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -64223,13 +69132,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>644283712</BitOffs>
+            <BitOffs>643248256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>644304960</BitOffs>
+            <BitOffs>643269504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -64263,13 +69172,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>644604352</BitOffs>
+            <BitOffs>643568896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m16</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>644625600</BitOffs>
+            <BitOffs>643590144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -64304,13 +69213,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>644924992</BitOffs>
+            <BitOffs>643889536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>644946240</BitOffs>
+            <BitOffs>643910784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -64345,13 +69254,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>645245632</BitOffs>
+            <BitOffs>644210176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>645266880</BitOffs>
+            <BitOffs>644231424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3</Name>
@@ -64374,7 +69283,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>645566272</BitOffs>
+            <BitOffs>644530816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats</Name>
@@ -64388,7 +69297,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>645586944</BitOffs>
+            <BitOffs>644551488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbYRMSErrorMR2L3</Name>
@@ -64403,19 +69312,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>646037440</BitOffs>
+            <BitOffs>645001984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646424320</BitOffs>
+            <BitOffs>645388864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinYRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646424384</BitOffs>
+            <BitOffs>645388928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbXRMSErrorMR2L3</Name>
@@ -64429,19 +69338,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>646424448</BitOffs>
+            <BitOffs>645388992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646811328</BitOffs>
+            <BitOffs>645775872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinXRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646811392</BitOffs>
+            <BitOffs>645775936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbPitchRMSErrorMR2L3</Name>
@@ -64455,19 +69364,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>646811456</BitOffs>
+            <BitOffs>645776000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPitchRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>647198336</BitOffs>
+            <BitOffs>646162880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinPitchRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>647198400</BitOffs>
+            <BitOffs>646162944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderRMSErrorMR2L3</Name>
@@ -64481,57 +69390,33 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647198464</BitOffs>
+            <BitOffs>646163008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBenderRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>647585344</BitOffs>
+            <BitOffs>646549888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinBenderRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>647585408</BitOffs>
+            <BitOffs>646549952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3PitchControl</Name>
             <Comment> Pitch Control</Comment>
-            <BitSize>365504</BitSize>
+            <BitSize>366848</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>647585472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR2L3PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>647950976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_PMPS.bMR1L3_OUT_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>647950984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_PMPS.bRemove</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>647950992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_PMPS.bExist</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>647951000</BitOffs>
+            <BitOffs>646550016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderMR2L3</Name>
             <Comment> Bender Control</Comment>
             <BitSize>128</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
-            <BitOffs>647951008</BitOffs>
+            <BitOffs>646916864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYupMR2L3</Name>
@@ -64548,7 +69433,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951136</BitOffs>
+            <BitOffs>646916992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYdwnMR2L3</Name>
@@ -64564,7 +69449,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951168</BitOffs>
+            <BitOffs>646917024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXupMR2L3</Name>
@@ -64580,7 +69465,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951200</BitOffs>
+            <BitOffs>646917056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXdwnMR2L3</Name>
@@ -64596,7 +69481,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951232</BitOffs>
+            <BitOffs>646917088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntPitchMR2L3</Name>
@@ -64612,7 +69497,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951264</BitOffs>
+            <BitOffs>646917120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYupMR2L3</Name>
@@ -64629,7 +69514,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951296</BitOffs>
+            <BitOffs>646917152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYdwnMR2L3</Name>
@@ -64645,7 +69530,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951328</BitOffs>
+            <BitOffs>646917184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXupMR2L3</Name>
@@ -64661,7 +69546,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951360</BitOffs>
+            <BitOffs>646917216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXdwnMR2L3</Name>
@@ -64677,7 +69562,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951392</BitOffs>
+            <BitOffs>646917248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefPitchMR2L3</Name>
@@ -64693,7 +69578,37 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951424</BitOffs>
+            <BitOffs>646917280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.mcReadParameterPitchMR2L3</Name>
+            <BitSize>4288</BitSize>
+            <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
+            <BitOffs>646917312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fEncRefPitchMR2L3_urad</Name>
+            <Comment> Current Pitch encoder offset in urad</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>646921600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fEncLeverArm_mm</Name>
+            <Comment> Common</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>513</Value>
+            </Default>
+            <BitOffs>646921664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbLogHandler</Name>
+            <Comment> Logging</Comment>
+            <BitSize>5784896</BitSize>
+            <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
+            <BitOffs>646921728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM1L3_RTD_1</Name>
@@ -64710,37 +69625,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647951456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.mcReadParameterPitchMR2L3</Name>
-            <BitSize>4288</BitSize>
-            <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>647951488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fEncRefPitchMR2L3_urad</Name>
-            <Comment> Current Pitch encoder offset in urad</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>647955776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fEncLeverArm_mm</Name>
-            <Comment> Common</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>513</Value>
-            </Default>
-            <BitOffs>647955840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbLogHandler</Name>
-            <Comment> Logging</Comment>
-            <BitSize>5784896</BitSize>
-            <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>647955904</BitOffs>
+            <BitOffs>652706624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM1L3_RTD_2</Name>
@@ -64757,7 +69642,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653740800</BitOffs>
+            <BitOffs>652706656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM1L3_RTD_3</Name>
@@ -64774,7 +69659,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653740832</BitOffs>
+            <BitOffs>652706688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM2L3_RTD_1</Name>
@@ -64791,7 +69676,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653740864</BitOffs>
+            <BitOffs>652706720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM2L3_RTD_2</Name>
@@ -64808,7 +69693,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653740896</BitOffs>
+            <BitOffs>652706752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM2L3_RTD_3</Name>
@@ -64825,7 +69710,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653740928</BitOffs>
+            <BitOffs>652706784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM1L4_RTD_1</Name>
@@ -64842,7 +69727,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653740960</BitOffs>
+            <BitOffs>652706816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM1L4_RTD_2</Name>
@@ -64859,7 +69744,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653740992</BitOffs>
+            <BitOffs>652706848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fM1L4_RTD_3</Name>
@@ -64876,13 +69761,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653741024</BitOffs>
+            <BitOffs>652706880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.nReq</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
-            <BitOffs>653746848</BitOffs>
+            <BitOffs>652744224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L3_Coating_States</Name>
@@ -64898,19 +69783,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
      </Value>
               </Property>
             </Properties>
-            <BitOffs>653746880</BitOffs>
+            <BitOffs>652744256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_SiC</Name>
             <BitSize>2944</BitSize>
             <BaseType Namespace="lcls_twincat_motion">DUT_PositionState</BaseType>
-            <BitOffs>654219648</BitOffs>
+            <BitOffs>653217024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_W</Name>
             <BitSize>2944</BitSize>
             <BaseType Namespace="lcls_twincat_motion">DUT_PositionState</BaseType>
-            <BitOffs>654222592</BitOffs>
+            <BitOffs>653219968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L3_InOut_States</Name>
@@ -64925,7 +69810,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654225536</BitOffs>
+            <BitOffs>653222912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_In</Name>
@@ -64961,7 +69846,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654462848</BitOffs>
+            <BitOffs>653460224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_Out</Name>
@@ -64997,7 +69882,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654465792</BitOffs>
+            <BitOffs>653463168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR2L3_Coating_States</Name>
@@ -65013,7 +69898,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654468736</BitOffs>
+            <BitOffs>653466112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR2L3_SiC</Name>
@@ -65049,7 +69934,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654706048</BitOffs>
+            <BitOffs>653703424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR2L3_W</Name>
@@ -65085,7 +69970,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654708992</BitOffs>
+            <BitOffs>653706368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L4_Coating_States</Name>
@@ -65101,7 +69986,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654711936</BitOffs>
+            <BitOffs>653709312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_SiC</Name>
@@ -65137,7 +70022,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654949248</BitOffs>
+            <BitOffs>653946624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_W</Name>
@@ -65173,7 +70058,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654952192</BitOffs>
+            <BitOffs>653949568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L4_InOut_States</Name>
@@ -65188,7 +70073,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654955136</BitOffs>
+            <BitOffs>653952512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_In</Name>
@@ -65224,7 +70109,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>655192448</BitOffs>
+            <BitOffs>654189824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_Out</Name>
@@ -65260,7 +70145,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>655195392</BitOffs>
+            <BitOffs>654192768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.fbM1</Name>
@@ -65301,7 +70186,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>655198496</BitOffs>
+            <BitOffs>654195904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.fbM2</Name>
@@ -65342,7 +70227,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>655251072</BitOffs>
+            <BitOffs>654248480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.fbM3</Name>
@@ -65383,7 +70268,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>655303648</BitOffs>
+            <BitOffs>654301056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.ffM1M2IN</Name>
@@ -65404,13 +70289,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1538</Value>
               </SubItem>
             </Default>
-            <BitOffs>655356224</BitOffs>
+            <BitOffs>654353632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>655381312</BitOffs>
+            <BitOffs>654378720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.ff2_ff1_link_vac</Name>
@@ -65434,27 +70319,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>39321</Value>
               </SubItem>
             </Default>
-            <BitOffs>655408480</BitOffs>
+            <BitOffs>654405888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.rtRemove</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>655433568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL.g_psLogHost</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="Tc2_System">T_IPv4Addr</BaseType>
-            <Default>
-              <String>172.21.32.9</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>655434368</BitOffs>
+            <BitOffs>654430976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gDefaultSubsystem</Name>
@@ -65468,7 +70339,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434496</BitOffs>
+            <BitOffs>654431712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gSystemFault</Name>
@@ -65479,7 +70350,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434512</BitOffs>
+            <BitOffs>654431728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gFirstPass</Name>
@@ -65493,7 +70364,21 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434568</BitOffs>
+            <BitOffs>654431736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL.g_psLogHost</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="Tc2_System">T_IPv4Addr</BaseType>
+            <Default>
+              <String>172.21.32.9</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>654431808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gM1STO</Name>
@@ -65505,7 +70390,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434592</BitOffs>
+            <BitOffs>654432000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gM2STO</Name>
@@ -65516,7 +70401,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434600</BitOffs>
+            <BitOffs>654432008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gM3STO</Name>
@@ -65527,7 +70412,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434608</BitOffs>
+            <BitOffs>654432016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gBypassVirtualLimits</Name>
@@ -65539,7 +70424,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434616</BitOffs>
+            <BitOffs>654432024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gEncScale</Name>
@@ -65555,7 +70440,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655434624</BitOffs>
+            <BitOffs>654432064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMaxVoltage</Name>
@@ -65569,7 +70454,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655449792</BitOffs>
+            <BitOffs>654447232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMinVoltage</Name>
@@ -65583,7 +70468,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655449856</BitOffs>
+            <BitOffs>654447296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nYUP_ENC_REF</Name>
@@ -65599,7 +70484,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655452416</BitOffs>
+            <BitOffs>654449856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nYDWN_ENC_REF</Name>
@@ -65613,7 +70498,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655452480</BitOffs>
+            <BitOffs>654449920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nXUP_ENC_REF</Name>
@@ -65627,7 +70512,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655452544</BitOffs>
+            <BitOffs>654449984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nXDWN_ENC_REF</Name>
@@ -65641,7 +70526,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655452608</BitOffs>
+            <BitOffs>654450048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nYUP_ENC_REF</Name>
@@ -65657,7 +70542,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455168</BitOffs>
+            <BitOffs>654452608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nYDWN_ENC_REF</Name>
@@ -65671,7 +70556,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455232</BitOffs>
+            <BitOffs>654452672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nXUP_ENC_REF</Name>
@@ -65685,7 +70570,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455296</BitOffs>
+            <BitOffs>654452736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nXDWN_ENC_REF</Name>
@@ -65699,7 +70584,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455360</BitOffs>
+            <BitOffs>654452800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nYUP_ENC_REF</Name>
@@ -65715,7 +70600,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455424</BitOffs>
+            <BitOffs>654452864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nYDWN_ENC_REF</Name>
@@ -65729,7 +70614,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455488</BitOffs>
+            <BitOffs>654452928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nXUP_ENC_REF</Name>
@@ -65743,7 +70628,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455552</BitOffs>
+            <BitOffs>654452992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nXDWN_ENC_REF</Name>
@@ -65757,7 +70642,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655455616</BitOffs>
+            <BitOffs>654453056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput1</Name>
@@ -65784,7 +70669,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655458176</BitOffs>
+            <BitOffs>654455616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2</Name>
@@ -65811,7 +70696,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655953472</BitOffs>
+            <BitOffs>654950912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter1</Name>
@@ -65831,7 +70716,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656448768</BitOffs>
+            <BitOffs>655446208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter2</Name>
@@ -65851,7 +70736,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656923392</BitOffs>
+            <BitOffs>655920832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO</Name>
@@ -65863,11 +70748,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657398016</BitOffs>
+            <BitOffs>656395456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
@@ -65878,11 +70763,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538040</BitOffs>
+            <BitOffs>656535448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>64</BitSize>
             <BaseType>VERSION</BaseType>
             <Default>
@@ -65896,7 +70781,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
               </SubItem>
               <SubItem>
                 <Name>.uiServicePack</Name>
-                <Value>6</Value>
+                <Value>13</Value>
               </SubItem>
               <SubItem>
                 <Name>.uiPatch</Name>
@@ -65908,11 +70793,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538048</BitOffs>
+            <BitOffs>656535456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>64</BitSize>
             <BaseType>VERSION</BaseType>
             <Default>
@@ -65926,11 +70811,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
               </SubItem>
               <SubItem>
                 <Name>.uiServicePack</Name>
-                <Value>10</Value>
+                <Value>13</Value>
               </SubItem>
               <SubItem>
                 <Name>.uiPatch</Name>
-                <Value>100</Value>
+                <Value>40</Value>
               </SubItem>
             </Default>
             <Properties>
@@ -65938,11 +70823,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538112</BitOffs>
+            <BitOffs>656535520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
@@ -65953,10 +70838,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538176</BitOffs>
+            <BitOffs>656535584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
@@ -65967,11 +70853,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538184</BitOffs>
+            <BitOffs>656535592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>16</BitSize>
             <BaseType>WORD</BaseType>
             <Default>
@@ -65982,11 +70868,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538192</BitOffs>
+            <BitOffs>656535600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
             <Default>
@@ -65997,35 +70883,51 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538208</BitOffs>
+            <BitOffs>656535616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bMulticoreSupport</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>656535632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>32</BitSize>
             <BaseType>DWORD</BaseType>
             <Default>
-              <Value>50660864</Value>
+              <Value>50662656</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538240</BitOffs>
+            <BitOffs>656535648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>32</BitSize>
             <BaseType>DWORD</BaseType>
             <Default>
-              <Value>50661988</Value>
+              <Value>50662696</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538272</BitOffs>
+            <BitOffs>656535680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -66146,7 +71048,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657538304</BitOffs>
+            <BitOffs>656535712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -66164,7 +71066,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657542400</BitOffs>
+            <BitOffs>656539840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -66178,7 +71080,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657545600</BitOffs>
+            <BitOffs>656543008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -66192,7 +71094,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657545632</BitOffs>
+            <BitOffs>656543040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -66213,60 +71115,63 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657547072</BitOffs>
+            <BitOffs>656544480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
-            <Comment> 11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31</Comment>
+            <Comment> BB2A9999-102E-421A-8D3D-B0660E07B1FE</Comment>
             <BitSize>128</BitSize>
             <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
             <Default>
               <SubItem>
                 <Name>.Data1</Name>
-                <Value>301464608</Value>
+                <Value>3140131225</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data2</Name>
-                <Value>56308</Value>
+                <Value>4142</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data3</Name>
-                <Value>19887</Value>
+                <Value>16922</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[0]</Name>
-                <Value>150</Value>
+                <Value>141</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[1]</Name>
-                <Value>199</Value>
+                <Value>61</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[2]</Name>
-                <Value>31</Value>
+                <Value>176</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[3]</Name>
-                <Value>214</Value>
+                <Value>102</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[4]</Name>
-                <Value>182</Value>
+                <Value>14</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[5]</Name>
-                <Value>21</Value>
+                <Value>7</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[6]</Name>
-                <Value>107</Value>
+                <Value>177</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[7]</Name>
-                <Value>49</Value>
+                <Value>254</Value>
               </SubItem>
             </Default>
             <Properties>
+              <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
               <Property>
                 <Name>tc_no_symbol</Name>
                 <Value>unused;ST_TcSystemEventClass</Value>
@@ -66282,60 +71187,63 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657563264</BitOffs>
+            <BitOffs>656562080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
-            <Comment> 98BCB284-F932-4EA4-B58B-68A1F1C34192</Comment>
+            <Comment> 7D760066-D373-4A0C-B0F1-328B1620B0F0</Comment>
             <BitSize>128</BitSize>
             <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
             <Default>
               <SubItem>
                 <Name>.Data1</Name>
-                <Value>2562503300</Value>
+                <Value>2104885350</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data2</Name>
-                <Value>63794</Value>
+                <Value>54131</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data3</Name>
-                <Value>20132</Value>
+                <Value>18956</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[0]</Name>
-                <Value>181</Value>
+                <Value>176</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[1]</Name>
-                <Value>139</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.Data4[2]</Name>
-                <Value>104</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.Data4[3]</Name>
-                <Value>161</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.Data4[4]</Name>
                 <Value>241</Value>
               </SubItem>
               <SubItem>
+                <Name>.Data4[2]</Name>
+                <Value>50</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[3]</Name>
+                <Value>139</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[4]</Name>
+                <Value>22</Value>
+              </SubItem>
+              <SubItem>
                 <Name>.Data4[5]</Name>
-                <Value>195</Value>
+                <Value>32</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[6]</Name>
-                <Value>65</Value>
+                <Value>176</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[7]</Name>
-                <Value>146</Value>
+                <Value>240</Value>
               </SubItem>
             </Default>
             <Properties>
+              <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
               <Property>
                 <Name>tc_no_symbol</Name>
                 <Value>unused;ST_TcGeneralAdsEventClass</Value>
@@ -66351,60 +71259,63 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657563392</BitOffs>
+            <BitOffs>656562208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
-            <Comment> E3D84344-4CB3-44DB-8D94-12F9CE0E2F90</Comment>
+            <Comment> E759605A-2341-48FC-9F3F-C8FA405C4B24</Comment>
             <BitSize>128</BitSize>
             <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
             <Default>
               <SubItem>
                 <Name>.Data1</Name>
-                <Value>3822601028</Value>
+                <Value>3881394266</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data2</Name>
-                <Value>19635</Value>
+                <Value>9025</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data3</Name>
-                <Value>17627</Value>
+                <Value>18684</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[0]</Name>
-                <Value>141</Value>
+                <Value>159</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[1]</Name>
-                <Value>148</Value>
+                <Value>63</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[2]</Name>
-                <Value>18</Value>
+                <Value>200</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[3]</Name>
-                <Value>249</Value>
+                <Value>250</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[4]</Name>
-                <Value>206</Value>
+                <Value>64</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[5]</Name>
-                <Value>14</Value>
+                <Value>92</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[6]</Name>
-                <Value>47</Value>
+                <Value>75</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[7]</Name>
-                <Value>144</Value>
+                <Value>36</Value>
               </SubItem>
             </Default>
             <Properties>
+              <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
               <Property>
                 <Name>tc_no_symbol</Name>
                 <Value>unused;ST_TcRouterEventClass</Value>
@@ -66420,60 +71331,63 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657563520</BitOffs>
+            <BitOffs>656562336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
-            <Comment> B63588AE-B30A-4DCE-A44F-F929FB114944</Comment>
+            <Comment> 92F05393-06A8-48C2-8871-EAA38C1E3990</Comment>
             <BitSize>128</BitSize>
             <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
             <Default>
               <SubItem>
                 <Name>.Data1</Name>
-                <Value>3056961710</Value>
+                <Value>2465223571</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data2</Name>
-                <Value>45834</Value>
+                <Value>1704</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data3</Name>
-                <Value>19918</Value>
+                <Value>18626</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[0]</Name>
-                <Value>164</Value>
+                <Value>136</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[1]</Name>
-                <Value>79</Value>
+                <Value>113</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[2]</Name>
-                <Value>249</Value>
+                <Value>234</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[3]</Name>
-                <Value>41</Value>
+                <Value>163</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[4]</Name>
-                <Value>251</Value>
+                <Value>140</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[5]</Name>
-                <Value>17</Value>
+                <Value>30</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[6]</Name>
-                <Value>73</Value>
+                <Value>57</Value>
               </SubItem>
               <SubItem>
                 <Name>.Data4[7]</Name>
-                <Value>68</Value>
+                <Value>144</Value>
               </SubItem>
             </Default>
             <Properties>
+              <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
               <Property>
                 <Name>tc_no_symbol</Name>
                 <Value>unused;ST_TcRTimeEventClass</Value>
@@ -66489,7 +71403,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657563648</BitOffs>
+            <BitOffs>656562464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -66544,6 +71458,9 @@ PMPS State Stage; bPowerSelf:=False</Comment>
             </Default>
             <Properties>
               <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
+              <Property>
                 <Name>tc_no_symbol</Name>
                 <Value>unused;ST_Win32EventClass</Value>
               </Property>
@@ -66558,7 +71475,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657563776</BitOffs>
+            <BitOffs>656562592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -66613,6 +71530,9 @@ PMPS State Stage; bPowerSelf:=False</Comment>
             </Default>
             <Properties>
               <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
+              <Property>
                 <Name>tc_no_symbol</Name>
                 <Value>unused;ST_LCLSGeneralEventClass</Value>
               </Property>
@@ -66627,7 +71547,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657563904</BitOffs>
+            <BitOffs>656562720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -66643,6 +71563,9 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>const_non_replaced</Name>
               </Property>
               <Property>
+                <Name>init_on_onlchange</Name>
+              </Property>
+              <Property>
                 <Name>suppress_warning_0</Name>
                 <Value>C0228</Value>
               </Property>
@@ -66650,14 +71573,14 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>657594368</BitOffs>
+            <BitOffs>656595872</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">36</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82968576</ByteSize>
+          <ByteSize>82837504</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -66675,7 +71598,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>3072000</BitOffs>
+            <BitOffs>633579808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AccumulatedFF</Name>
@@ -66694,7 +71617,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>3072032</BitOffs>
+            <BitOffs>633579840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.BP_jsonDoc</Name>
@@ -66705,23 +71628,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>3072064</BitOffs>
+            <BitOffs>633579872</BitOffs>
           </Symbol>
         </DataArea>
       </DataAreas>
       <Deployment/>
       <EventClasses>
         <EventClass>
-          <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
+          <Type GUID="{BB2A9999-102E-421A-8D3D-B0660E07B1FE}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
-          <Type GUID="{98BCB284-F932-4EA4-B58B-68A1F1C34192}">TcGeneralAdsEventClass</Type>
+          <Type GUID="{7D760066-D373-4A0C-B0F1-328B1620B0F0}">TcGeneralAdsEventClass</Type>
         </EventClass>
         <EventClass>
-          <Type GUID="{E3D84344-4CB3-44DB-8D94-12F9CE0E2F90}">TcRouterEventClass</Type>
+          <Type GUID="{E759605A-2341-48FC-9F3F-C8FA405C4B24}">TcRouterEventClass</Type>
         </EventClass>
         <EventClass>
-          <Type GUID="{B63588AE-B30A-4DCE-A44F-F929FB114944}">TcRTimeEventClass</Type>
+          <Type GUID="{92F05393-06A8-48C2-8871-EAA38C1E3990}">TcRTimeEventClass</Type>
         </EventClass>
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
@@ -66737,15 +71660,15 @@ PMPS State Stage; bPowerSelf:=False</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-06-20T10:53:52</Value>
+          <Value>2023-06-21T11:07:38</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>663552</Value>
+          <Value>684032</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>81772544</Value>
+          <Value>81776640</Value>
         </Property>
       </Properties>
     </Module>

--- a/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
+++ b/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{C007E115-1A1B-DA93-103F-FDB135236BEC}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{5EF6A122-29A6-3613-9D05-5DD1880F707A}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -3064,7 +3064,7 @@
       <SubItem>
         <Name>i_xExecute</Name>
         <Type>BOOL</Type>
-        <Comment> rising edge execute </Comment>
+        <Comment> rising edge execute</Comment>
         <BitSize>8</BitSize>
         <BitOffs>32</BitOffs>
         <Properties>
@@ -3077,7 +3077,7 @@
       <SubItem>
         <Name>i_tTimeOut</Name>
         <Type>TIME</Type>
-        <Comment> Maximum wait time for reply </Comment>
+        <Comment> Maximum wait time for reply</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
@@ -3208,7 +3208,7 @@
       <SubItem>
         <Name>q_sLastSentString</Name>
         <Type>STRING(80)</Type>
-        <Comment> Last String Sent to Serial Device - for debugging </Comment>
+        <Comment> Last String Sent to Serial Device - for debugging</Comment>
         <BitSize>648</BitSize>
         <BitOffs>8968</BitOffs>
         <Properties>
@@ -3221,7 +3221,7 @@
       <SubItem>
         <Name>q_sLastReceivedString</Name>
         <Type>STRING(80)</Type>
-        <Comment> Last String Received from Serial Device - for debugging </Comment>
+        <Comment> Last String Received from Serial Device - for debugging</Comment>
         <BitSize>648</BitSize>
         <BitOffs>9616</BitOffs>
         <Properties>
@@ -3383,7 +3383,7 @@
       <SubItem>
         <Name>i_xExecute</Name>
         <Type>BOOL</Type>
-        <Comment> rising edge execute </Comment>
+        <Comment> rising edge execute</Comment>
         <BitSize>8</BitSize>
         <BitOffs>32</BitOffs>
         <Properties>
@@ -3396,7 +3396,7 @@
       <SubItem>
         <Name>i_tTimeOut</Name>
         <Type>TIME</Type>
-        <Comment> Maximum wait time for reply </Comment>
+        <Comment> Maximum wait time for reply</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
@@ -3452,7 +3452,7 @@
           <LBound>1</LBound>
           <Elements>50</Elements>
         </ArrayInfo>
-        <Comment> Last Strings Sent to Serial Device - for debugging </Comment>
+        <Comment> Last Strings Sent to Serial Device - for debugging</Comment>
         <BitSize>32400</BitSize>
         <BitOffs>2160</BitOffs>
         <Properties>
@@ -3469,7 +3469,7 @@
           <LBound>1</LBound>
           <Elements>50</Elements>
         </ArrayInfo>
-        <Comment> Last Strings Received from Serial Device - for debugging </Comment>
+        <Comment> Last Strings Received from Serial Device - for debugging</Comment>
         <BitSize>32400</BitSize>
         <BitOffs>34560</BitOffs>
         <Properties>
@@ -54285,7 +54285,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_MR1L3</Name>
             <Comment> M1L3 In Serial Comm Array</Comment>
@@ -54416,7 +54416,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_MR1L3</Name>
             <Comment> M1 Out Serual Comm Array</Comment>
@@ -54545,7 +54545,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_MR1L3</Name>
             <Comment> M1 Serial Comm Function Block</Comment>
@@ -54701,7 +54701,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
             <Comment> Global hash prefix type constant used for binary, octal or hexadecimal string format type </Comment>
@@ -55312,7 +55312,7 @@ Beckhoff</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">32</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -60058,7 +60058,7 @@ Beckhoff</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">33</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -61261,7 +61261,7 @@ Beckhoff</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -67683,7 +67683,7 @@ Beckhoff</Comment>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>0</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -67695,7 +67695,7 @@ Beckhoff</Comment>
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>0.6.0</String>
+                <String>0.6.1</String>
               </SubItem>
             </Default>
             <Properties>
@@ -71580,7 +71580,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">36</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>2</ContextId>
-          <ByteSize>82837504</ByteSize>
+          <ByteSize>82903040</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -71660,7 +71660,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-06-21T11:07:38</Value>
+          <Value>2023-06-21T11:18:05</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/HOMS_XRT/_Config/NC/NC.xti
+++ b/HOMS_XRT/_Config/NC/NC.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcSafTaskDef" SubType="0">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CNcSafTaskDef" SubType="0">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -272,15 +272,13 @@
 			<SubItem>
 				<Name>nState4</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-				<Comment>
-					<![CDATA[Drive Status 4 (automatically linked):
+				<Comment><![CDATA[Drive Status 4 (automatically linked):
 0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
 
 Drive Status 4 (manually linked):
 0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>88</BitOffs>
 			</SubItem>
@@ -329,6 +327,8 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>nState8</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
+				<Comment><![CDATA[Digital Inputs 1..8
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>248</BitOffs>
 			</SubItem>
@@ -1042,8 +1042,7 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -1057,8 +1056,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -1071,8 +1069,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -1080,22 +1077,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -1333,21 +1327,21 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"/>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1546,11 +1540,11 @@ External Setpoint Generation:
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1563,8 +1557,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -1578,8 +1571,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -1592,8 +1584,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -1601,22 +1592,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -1842,13 +1830,13 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -1878,7 +1866,7 @@ External Setpoint Generation:
 		<Axis File="M1L3-Xdwn.xti" Id="4"/>
 		<Axis File="M1L3-Pitch.xti" Id="5"/>
 		<Axis File="M1L3-Bender.xti" Id="6"/>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M2L3" Id="13">
+		<Axis Id="13" CreateSymbols="true" AxisType="1" AxisFolder="M2L3" GroupId="7">
 			<Name>M2L3-Yup</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -1900,25 +1888,21 @@ External Setpoint Generation:
 						<BitOffs>12928</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -1948,18 +1932,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -1988,23 +1960,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -2042,55 +2010,10 @@ Drive Status 4 (manually linked):
 					<Name>ToPlc</Name>
 					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<BitOffs>18048</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M2L3" Id="14">
+		<Axis Id="14" CreateSymbols="true" AxisType="1" AxisFolder="M2L3" GroupId="8">
 			<Name>M2L3-Ydwn</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -2103,7 +2026,6 @@ External Setpoint Generation:
 					<SoftEndMinControl Enable="true" Range="-11750"/>
 					<SoftEndMaxControl Enable="true" Range="12531.5"/>
 					<Inc RefSoftSyncMask="#x0000ffff"/>
-					<ParameterChanged>7</ParameterChanged>
 				</EncPara>
 				<Vars VarGrpType="1">
 					<Name>Inputs</Name>
@@ -2113,25 +2035,21 @@ External Setpoint Generation:
 						<BitOffs>14912</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -2161,18 +2079,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -2201,23 +2107,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -2255,55 +2157,10 @@ Drive Status 4 (manually linked):
 					<Name>ToPlc</Name>
 					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<BitOffs>21056</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M2L3" Id="15">
+		<Axis Id="15" CreateSymbols="true" AxisType="1" AxisFolder="M2L3" GroupId="9">
 			<Name>M2L3-Xup</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -2325,25 +2182,21 @@ External Setpoint Generation:
 						<BitOffs>16896</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -2373,18 +2226,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -2413,23 +2254,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -2467,55 +2304,10 @@ Drive Status 4 (manually linked):
 					<Name>ToPlc</Name>
 					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<BitOffs>24064</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M2L3" Id="16">
+		<Axis Id="16" CreateSymbols="true" AxisType="1" AxisFolder="M2L3" GroupId="10">
 			<Name>M2L3-Xdwn</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -2537,25 +2329,21 @@ External Setpoint Generation:
 						<BitOffs>18880</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -2585,18 +2373,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -2625,23 +2401,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -2679,55 +2451,10 @@ Drive Status 4 (manually linked):
 					<Name>ToPlc</Name>
 					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<BitOffs>27072</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M2L3" Id="17">
+		<Axis Id="17" CreateSymbols="true" AxisType="1" AxisFolder="M2L3" GroupId="11">
 			<Name>M2L3-Pitch</Name>
 			<AxisPara>
 				<General UnitName="urad"/>
@@ -2750,25 +2477,21 @@ External Setpoint Generation:
 						<BitOffs>20864</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -2798,18 +2521,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -2838,23 +2549,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -2892,55 +2599,10 @@ Drive Status 4 (manually linked):
 					<Name>ToPlc</Name>
 					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<BitOffs>30080</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M2L3" Id="18">
+		<Axis Id="18" CreateSymbols="true" AxisType="1" AxisFolder="M2L3" GroupId="12">
 			<Name>M2L3-Bender</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -2962,25 +2624,21 @@ External Setpoint Generation:
 						<BitOffs>22848</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -3010,18 +2668,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -3050,23 +2696,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -3103,55 +2745,10 @@ Drive Status 4 (manually linked):
 					<Name>ToPlc</Name>
 					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<BitOffs>33088</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M1L4" Id="7">
+		<Axis Id="7" CreateSymbols="true" AxisType="1" AxisFolder="M1L4" GroupId="13">
 			<Name>M1L4-Yup</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -3173,25 +2770,21 @@ External Setpoint Generation:
 						<BitOffs>24832</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -3221,18 +2814,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -3261,23 +2842,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -3313,57 +2890,12 @@ Drive Status 4 (manually linked):
 				<Name>Outputs</Name>
 				<Var>
 					<Name>ToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 					<BitOffs>36096</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M1L4" Id="8">
+		<Axis Id="8" CreateSymbols="true" AxisType="1" AxisFolder="M1L4" GroupId="14">
 			<Name>M1L4-Ydwn</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -3385,25 +2917,21 @@ External Setpoint Generation:
 						<BitOffs>26816</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -3433,18 +2961,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -3473,23 +2989,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -3525,57 +3037,12 @@ Drive Status 4 (manually linked):
 				<Name>Outputs</Name>
 				<Var>
 					<Name>ToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 					<BitOffs>39104</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M1L4" Id="9">
+		<Axis Id="9" CreateSymbols="true" AxisType="1" AxisFolder="M1L4" GroupId="15">
 			<Name>M1L4-Xup</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -3597,25 +3064,21 @@ External Setpoint Generation:
 						<BitOffs>28800</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -3645,18 +3108,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -3685,23 +3136,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -3737,57 +3184,12 @@ Drive Status 4 (manually linked):
 				<Name>Outputs</Name>
 				<Var>
 					<Name>ToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 					<BitOffs>42112</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M1L4" Id="10">
+		<Axis Id="10" CreateSymbols="true" AxisType="1" AxisFolder="M1L4" GroupId="16">
 			<Name>M1L4-Xdwn</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -3809,25 +3211,21 @@ External Setpoint Generation:
 						<BitOffs>30784</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -3857,18 +3255,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -3897,23 +3283,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -3949,57 +3331,12 @@ Drive Status 4 (manually linked):
 				<Name>Outputs</Name>
 				<Var>
 					<Name>ToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 					<BitOffs>45120</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M1L4" Id="11">
+		<Axis Id="11" CreateSymbols="true" AxisType="1" AxisFolder="M1L4" GroupId="17">
 			<Name>M1L4-Pitch</Name>
 			<AxisPara>
 				<General UnitName="urad"/>
@@ -4022,25 +3359,21 @@ External Setpoint Generation:
 						<BitOffs>32768</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -4070,18 +3403,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -4110,23 +3431,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -4162,57 +3479,12 @@ Drive Status 4 (manually linked):
 				<Name>Outputs</Name>
 				<Var>
 					<Name>ToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 					<BitOffs>48128</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
-		<Axis CreateSymbols="true" AxisType="1" AxisFolder="M1L4" Id="12">
+		<Axis Id="12" CreateSymbols="true" AxisType="1" AxisFolder="M1L4" GroupId="18">
 			<Name>M1L4-Bender</Name>
 			<AxisPara>
 				<General UnitName="um"/>
@@ -4233,25 +3505,21 @@ External Setpoint Generation:
 						<BitOffs>34752</BitOffs>
 						<SubVar>
 							<Name>nState1</Name>
-							<Comment>
-								<![CDATA[Encoder State 1 (automatically linked):
+							<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nComState</Name>
-							<Comment>
-								<![CDATA[Encoder Communication State (automatically linked):
+							<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 					</Var>
 				</Vars>
@@ -4281,18 +3549,6 @@ External Setpoint Generation:
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn2</Name>
 						</SubVar>
-						<SubVar>
-							<Name>nState4</Name>
-							<Comment>
-								<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-							</Comment>
-						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataIn3</Name>
 						</SubVar>
@@ -4321,23 +3577,19 @@ Drive Status 4 (manually linked):
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl2</Name>
-							<Comment>
-								<![CDATA[Digital Outputs Setpoint Generator:
+							<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar>
 							<Name>nCtrl3</Name>
-							<Comment>
-								<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+							<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-							</Comment>
+]]></Comment>
 						</SubVar>
 						<SubVar TypeFormatIndex="2">
 							<Name>nDataOut3</Name>
@@ -4373,53 +3625,8 @@ Drive Status 4 (manually linked):
 				<Name>Outputs</Name>
 				<Var>
 					<Name>ToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 					<BitOffs>51136</BitOffs>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
 		</Axis>
@@ -4428,21 +3635,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M1L4-Bender">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL5042_M1L4_PitchBender">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Bender">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4450,8 +3657,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4460,21 +3667,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M1L4-Pitch">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL5042_M1L4_PitchBender">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_PitchCoarse">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4482,8 +3689,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4492,21 +3699,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M1L4-Xdwn">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL5042_M1L4_Xupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Xdwn">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4514,8 +3721,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4524,21 +3731,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M1L4-Xup">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL5042_M1L4_Xupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Xup">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4546,8 +3753,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4556,21 +3763,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M1L4-Ydwn">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL5042_M1L4_Yupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Ydwn">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4578,8 +3785,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4588,21 +3795,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M1L4-Yup">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL5042_M1L4_Yupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Yup">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4610,8 +3817,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4620,21 +3827,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M2L3-Bender">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL5042_M2L3_PitchBender">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Bender">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4642,8 +3849,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4652,21 +3859,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M2L3-Pitch">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL5042_M2L3_PitchBender">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_PitchCoarse">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4674,8 +3881,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4684,21 +3891,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M2L3-Xdwn">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL5042_M2L3_Xupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Xdwn">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4706,8 +3913,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4716,21 +3923,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M2L3-Xup">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL5042_M2L3_Xupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Xup">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4738,8 +3945,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4748,21 +3955,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M2L3-Ydwn">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL5042_M2L3_Yupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Ydwn">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4770,8 +3977,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>
@@ -4780,21 +3987,21 @@ External Setpoint Generation:
 		<OwnerA Name="Axes^M2L3-Yup">
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL5042_M2L3_Yupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Yup">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -4802,8 +4009,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nDataOut2[0]" VarB="STM Velocity^Velocity"/>

--- a/HOMS_XRT/_Config/PLC/HOMS_XRT_PLC.xti
+++ b/HOMS_XRT/_Config/PLC/HOMS_XRT_PLC.xti
@@ -1,16 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNestedPlcProjDef">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CNestedPlcProjDef">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{3749F519-7E88-4D20-B8BB-B17B89339572}" Namespace="Tc2_SerialCom" AutoDeleteType="true">EL6inData22B</Name>
-			<Comment>
-				<![CDATA[ This data type is corresponding to the
+			<Comment><![CDATA[ This data type is corresponding to the
    KL-6xxx data structure used in the
    TwinCAT SystemManager
    (KL-6xxx version using 5 data bytes / 
     non-alternative (standard) output ) 
-]]>
-			</Comment>
+]]></Comment>
 			<BitSize>192</BitSize>
 			<SubItem>
 				<Name>Status</Name>
@@ -31,14 +29,12 @@
 		</DataType>
 		<DataType>
 			<Name GUID="{0AA5827D-90D1-4FE0-B7CD-129DA7259C0C}" Namespace="Tc2_SerialCom" AutoDeleteType="true">EL6outData22B</Name>
-			<Comment>
-				<![CDATA[ This data type is corresponding to the
+			<Comment><![CDATA[ This data type is corresponding to the
    KL-6xxx data structure used in the
    TwinCAT SystemManager
    (KL-6xxx version using 5 data bytes / 
     non-alternative (standard) output ) 
-]]>
-			</Comment>
+]]></Comment>
 			<BitSize>192</BitSize>
 			<SubItem>
 				<Name>Ctrl</Name>
@@ -58,7 +54,7 @@
 			</SubItem>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -169,6 +165,12 @@
 				<BitOffs>17</BitOffs>
 			</SubItem>
 			<SubItem>
+				<Name>IsDriveLimitActive</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>18</BitOffs>
+			</SubItem>
+			<SubItem>
 				<Name>ContinuousMotion</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
 				<BitSize>1</BitSize>
@@ -255,6 +257,11 @@
 			<Format Name="IEC">
 				<Printf>16#%08X</Printf>
 			</Format>
+			<Relations>
+				<Relation Priority="100">
+					<Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
+				</Relation>
+			</Relations>
 		</DataType>
 		<DataType>
 			<Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
@@ -450,11 +457,11 @@
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -467,8 +474,7 @@
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -482,8 +488,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -496,8 +501,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -505,22 +509,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -709,6 +710,18 @@ External Setpoint Generation:
 				<BitOffs>1600</BitOffs>
 			</SubItem>
 			<SubItem>
+				<Name>AbsPhasingPos</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>1664</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>TorqueOffset</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>1728</BitOffs>
+			</SubItem>
+			<SubItem>
 				<Name>ActPosWithoutPosCorrection</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
 				<BitSize>64</BitSize>
@@ -746,36 +759,35 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
+				</Relation>
+				<Relation Priority="100">
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{D7E1C4B1-4774-4B8E-BC03-802FD5ACE8C5}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
+			<Name GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
 			<BitSize>0</BitSize>
 			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
 			<Hides>
-				<Hide GUID="{91123A73-57E8-4949-B2D7-A26573D389F0}"/>
+				<Hide GUID="{BD62FA19-0392-49CE-B431-B6E6DCEB0242}"/>
 			</Hides>
 		</DataType>
 		<DataType>
-			<Name GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
-			<Comment>
-				<![CDATA[Renishaw BiSS-C absolute encoder used with an EL5042]]>
-			</Comment>
+			<Name GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
+			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
 			<BitSize>128</BitSize>
 			<SubItem>
 				<Name>Count</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment>
-					<![CDATA[Connect to encoder "Position" input]]>
-				</Comment>
+				<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 				<BitSize>64</BitSize>
 				<BitOffs>0</BitOffs>
 				<Properties>
@@ -787,24 +799,20 @@ External Setpoint Generation:
 			</SubItem>
 			<SubItem>
 				<Name>Status</Name>
-				<Type GUID="{D7E1C4B1-4774-4B8E-BC03-802FD5ACE8C5}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
-				<Comment>
-					<![CDATA[Status struct placeholder]]>
-				</Comment>
+				<Type GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
+				<Comment><![CDATA[ Status struct placeholder]]></Comment>
 				<BitSize>0</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>Ref</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment>
-					<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-				</Comment>
+				<Comment><![CDATA[ Encoder zero position (useful for aligned position with gantries)]]></Comment>
 				<BitSize>64</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
 			<Hides>
-				<Hide GUID="{D9CF9222-AA0D-441C-981E-0A3F76DB5C43}"/>
+				<Hide GUID="{D11CA7B1-E31C-4236-92DC-F5030CF26F93}"/>
 			</Hides>
 		</DataType>
 		<DataType>
@@ -858,9 +866,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>Width</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-				<Comment>
-					<![CDATA[ distance between horizontal slits (x)]]>
-				</Comment>
+				<Comment><![CDATA[ distance between horizontal slits (x)]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 				<Properties>
@@ -875,9 +881,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>Height</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-				<Comment>
-					<![CDATA[ distance between vertical slits (y)]]>
-				</Comment>
+				<Comment><![CDATA[ distance between vertical slits (y)]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>32</BitOffs>
 				<Properties>
@@ -892,9 +896,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>xOK</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-				<Comment>
-					<![CDATA[ status of aperture, false if error or in motion]]>
-				</Comment>
+				<Comment><![CDATA[ status of aperture, false if error or in motion]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>64</BitOffs>
 				<Properties>
@@ -912,9 +914,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>nTran</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-				<Comment TxtId="">
-					<![CDATA[Requested pre-optic attenuation - 1 is full transmission]]>
-				</Comment>
+				<Comment TxtId=""><![CDATA[Requested pre-optic attenuation - 1 is full transmission]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 				<Default>
@@ -933,9 +933,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>nRate</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[ Pulse-rate ]]>
-				</Comment>
+				<Comment><![CDATA[ Pulse-rate ]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>32</BitOffs>
 				<Default>
@@ -952,9 +950,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>neVRange</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-				<Comment>
-					<![CDATA[ Photon energy ranges ]]>
-				</Comment>
+				<Comment><![CDATA[ Photon energy ranges ]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 				<Default>
@@ -975,9 +971,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>neV</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000D}">REAL</Type>
-				<Comment TxtId="">
-					<![CDATA[Current Photon energy as calculated by the arbiter]]>
-				</Comment>
+				<Comment TxtId=""><![CDATA[Current Photon energy as calculated by the arbiter]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>96</BitOffs>
 			</SubItem>
@@ -1015,9 +1009,7 @@ External Setpoint Generation:
 					<LBound>1</LBound>
 					<Elements>16</Elements>
 				</ArrayInfo>
-				<Comment>
-					<![CDATA[ Beamline attenuators ]]>
-				</Comment>
+				<Comment><![CDATA[ Beamline attenuators ]]></Comment>
 				<BitSize>1024</BitSize>
 				<BitOffs>160</BitOffs>
 				<Properties>
@@ -1045,9 +1037,7 @@ External Setpoint Generation:
 					<LBound>1</LBound>
 					<Elements>16</Elements>
 				</ArrayInfo>
-				<Comment>
-					<![CDATA[ Stopper statuses ]]>
-				</Comment>
+				<Comment><![CDATA[ Stopper statuses ]]></Comment>
 				<BitSize>128</BitSize>
 				<BitOffs>1568</BitOffs>
 				<Properties>
@@ -1061,18 +1051,14 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>xValidToggle</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-				<Comment>
-					<![CDATA[ Toggle for watchdog]]>
-				</Comment>
+				<Comment><![CDATA[ Toggle for watchdog]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>1696</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>xValid</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-				<Comment>
-					<![CDATA[ Beam parameter set is valid (if readback), or acknowledged (if request)]]>
-				</Comment>
+				<Comment><![CDATA[ Beam parameter set is valid (if readback), or acknowledged (if request)]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>1704</BitOffs>
 				<Properties>
@@ -1086,9 +1072,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>nCohortInt</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[ Cohort index. Identifies which cohort this BP set was included in arbitration]]>
-				</Comment>
+				<Comment><![CDATA[ Cohort index. Identifies which cohort this BP set was included in arbitration]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>1728</BitOffs>
 				<Properties>
@@ -1313,9 +1297,7 @@ External Setpoint Generation:
 				<Name>SerialIO Inputs</Name>
 				<Var>
 					<Name>GVL_SerialIO.Serial_stComIn_MR1L3</Name>
-					<Comment>
-						<![CDATA[ M1L3 In Serial Comm Array]]>
-					</Comment>
+					<Comment><![CDATA[ M1L3 In Serial Comm Array]]></Comment>
 					<Type GUID="{3749F519-7E88-4D20-B8BB-B17B89339572}" Namespace="Tc2_SerialCom">EL6inData22B</Type>
 				</Var>
 				<Var>
@@ -1324,932 +1306,296 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_SerialIO.Serial_stComIn_MR2L3</Name>
-					<Comment>
-						<![CDATA[ M3 In Serial Comm Array]]>
-					</Comment>
+					<Comment><![CDATA[ M3 In Serial Comm Array]]></Comment>
 					<Type GUID="{3749F519-7E88-4D20-B8BB-B17B89339572}" Namespace="Tc2_SerialCom">EL6inData22B</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="2">
+			<Vars VarGrpType="2" AreaNo="1">
 				<Name>SerialIO Outputs</Name>
 				<Var>
 					<Name>GVL_SerialIO.Serial_stComOut_MR1L3</Name>
-					<Comment>
-						<![CDATA[ M1 Out Serual Comm Array]]>
-					</Comment>
+					<Comment><![CDATA[ M1 Out Serual Comm Array]]></Comment>
 					<Type GUID="{0AA5827D-90D1-4FE0-B7CD-129DA7259C0C}" Namespace="Tc2_SerialCom">EL6outData22B</Type>
 				</Var>
 				<Var>
 					<Name>GVL_SerialIO.Serial_stComOut_MR1L4</Name>
-					<Comment>
-						<![CDATA[ xrt M2 MR1L4 Out Serual Comm Array]]>
-					</Comment>
+					<Comment><![CDATA[ xrt M2 MR1L4 Out Serual Comm Array]]></Comment>
 					<Type GUID="{0AA5827D-90D1-4FE0-B7CD-129DA7259C0C}" Namespace="Tc2_SerialCom">EL6outData22B</Type>
 				</Var>
 				<Var>
 					<Name>GVL_SerialIO.Serial_stComOut_MR2L3</Name>
-					<Comment>
-						<![CDATA[ M3 Out Serual Comm Array]]>
-					</Comment>
+					<Comment><![CDATA[ M3 Out Serual Comm Array]]></Comment>
 					<Type GUID="{0AA5827D-90D1-4FE0-B7CD-129DA7259C0C}" Namespace="Tc2_SerialCom">EL6outData22B</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="1">
+			<Vars VarGrpType="1" ContextId="2" AreaNo="32">
 				<Name>PlcTask Inputs</Name>
 				<Var>
 					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-					<Comment>
-						<![CDATA[Raw encoder count]]>
-					</Comment>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.bSTOEnable1</Name>
-					<Comment>
-						<![CDATA[ STO Button]]>
-					</Comment>
+					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -2258,128 +1604,44 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.stYupEnc</Name>
-					<Comment>
-						<![CDATA[ Encoders]]>
-					</Comment>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
-					<Comment>
-						<![CDATA[ STO Button]]>
-					</Comment>
+					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -2388,1255 +1650,384 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stYupEnc</Name>
-					<Comment>
-						<![CDATA[ Encoders]]>
-					</Comment>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m7.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M8.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m8.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M9.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m9.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M10.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m10.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M11.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m11.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M12.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.bSTOEnable1</Name>
-					<Comment>
-						<![CDATA[ STO Button]]>
-					</Comment>
+					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -3645,128 +2036,44 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.stYupEnc</Name>
-					<Comment>
-						<![CDATA[ Encoders]]>
-					</Comment>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
-					<Comment>
-						<![CDATA[ STO Button]]>
-					</Comment>
+					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -3775,1255 +2082,384 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stYupEnc</Name>
-					<Comment>
-						<![CDATA[ Encoders]]>
-					</Comment>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M13.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M14.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M15.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M16.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M17.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M18.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.bSTOEnable1</Name>
-					<Comment>
-						<![CDATA[ STO Button]]>
-					</Comment>
+					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5032,128 +2468,44 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.stYupEnc</Name>
-					<Comment>
-						<![CDATA[ Encoders]]>
-					</Comment>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
-					<Comment>
-						<![CDATA[ STO Button]]>
-					</Comment>
+					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5162,367 +2514,122 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stYupEnc</Name>
-					<Comment>
-						<![CDATA[ Encoders]]>
-					</Comment>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{D5C88773-410D-4700-B4CE-D1B5638FA1AB}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>GVL.gAmsNetIDEcatMaster1</Name>
@@ -5530,10 +2637,8 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_RTDS.nM1L3_RTD_1</Name>
-					<Comment>
-						<![CDATA[ M2K4 BENDER RTDs
- M1L3 RTDs]]>
-					</Comment>
+					<Comment><![CDATA[ M2K4 BENDER RTDs
+ M1L3 RTDs]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -5541,155 +2646,32 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>GVL_RTDS.nM1L3_RTD_3</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.nM2L3_RTD_1</Name>
+					<Comment><![CDATA[ M2L3 RTDs]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_MR1L3.MR1L3_Pitch.diEncCnt</Name>
-					<Comment>
-						<![CDATA[Raw encoder count]]>
-					</Comment>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_MR1L4.MR1L4_Pitch.diEncCnt</Name>
-					<Comment>
-						<![CDATA[Raw encoder count]]>
-					</Comment>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_MR2L3.MR2L3_Pitch.diEncCnt</Name>
-					<Comment>
-						<![CDATA[Raw encoder count]]>
-					</Comment>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbArbiterIO.i_stCurrentBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
-					<SubVar>
-						<Name>nTran</Name>
-						<Comment>
-							<![CDATA[Requested pre-optic attenuation - 1 is full transmission]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>nRate</Name>
-						<Comment>
-							<![CDATA[ Pulse-rate ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>neVRange</Name>
-						<Comment>
-							<![CDATA[ Photon energy ranges ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>neV</Name>
-						<Comment>
-							<![CDATA[Current Photon energy as calculated by the arbiter]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astAttenuators</Name>
-						<Comment>
-							<![CDATA[ Beamline attenuators ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[1]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[1]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[1]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[2]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[2]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[2]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[3]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[3]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[3]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[4]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[4]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[4]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>aVetoDevices</Name>
-						<Comment>
-							<![CDATA[ Stopper statuses ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>xValidToggle</Name>
-						<Comment>
-							<![CDATA[ Toggle for watchdog]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>xValid</Name>
-						<Comment>
-							<![CDATA[ Beam parameter set is valid (if readback), or acknowledged (if request)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>nCohortInt</Name>
-						<Comment>
-							<![CDATA[ Cohort index. Identifies which cohort this BP set was included in arbitration]]>
-						</Comment>
-					</SubVar>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbArbiterIO.xTxPDO_toggle</Name>
@@ -5698,17 +2680,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>GVL_PMPS.fbArbiterIO.xTxPDO_state</Name>
 					<Type>BIT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_RTDS.nM1L3_RTD_3</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_RTDS.nM2L3_RTD_1</Name>
-					<Comment>
-						<![CDATA[ M2L3 RTDs]]>
-					</Comment>
-					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_RTDS.nM2L3_RTD_2</Name>
@@ -5720,9 +2691,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_RTDS.nM1L4_RTD_1</Name>
-					<Comment>
-						<![CDATA[ M1L4 RTDs]]>
-					</Comment>
+					<Comment><![CDATA[ M1L4 RTDs]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -5734,7 +2703,7 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="2">
+			<Vars VarGrpType="2" ContextId="2" AreaNo="33">
 				<Name>PlcTask Outputs</Name>
 				<Var>
 					<Name>Main.M1.Axis.PlcToNc</Name>
@@ -5742,9 +2711,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M1.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5757,9 +2724,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5772,9 +2737,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M3.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5787,9 +2750,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M4.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5802,9 +2763,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M5.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5817,9 +2776,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M6.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5832,9 +2789,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamY.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5843,9 +2798,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L3GantryStats.fbUpStreamX.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5858,9 +2811,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M7.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5873,9 +2824,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M8.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5888,9 +2837,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M9.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5903,9 +2850,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M10.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5918,9 +2863,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M11.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5933,9 +2876,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M12.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5948,9 +2889,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamY.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5959,9 +2898,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR1L4GantryStats.fbUpStreamX.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5974,9 +2911,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M13.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5989,9 +2924,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M14.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6004,9 +2937,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M15.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6019,9 +2950,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M16.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6034,9 +2963,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M17.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6049,9 +2976,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M18.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6064,9 +2989,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamY.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6075,9 +2998,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMR2L3GantryStats.fbUpStreamX.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6086,9 +3007,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL.bXRT_M2_OUT</Name>
-					<Comment>
-						<![CDATA[MPS Outputs]]>
-					</Comment>
+					<Comment><![CDATA[MPS Outputs]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6106,149 +3025,19 @@ External Setpoint Generation:
 				<Var>
 					<Name>GVL_PMPS.fbArbiterIO.q_stRequestedBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
-					<SubVar>
-						<Name>nTran</Name>
-						<Comment>
-							<![CDATA[Requested pre-optic attenuation - 1 is full transmission]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>nRate</Name>
-						<Comment>
-							<![CDATA[ Pulse-rate ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>neVRange</Name>
-						<Comment>
-							<![CDATA[ Photon energy ranges ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>neV</Name>
-						<Comment>
-							<![CDATA[Current Photon energy as calculated by the arbiter]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astAttenuators</Name>
-						<Comment>
-							<![CDATA[ Beamline attenuators ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[1]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[1]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[1]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[2]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[2]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[2]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[3]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[3]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[3]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[4]^Width</Name>
-						<Comment>
-							<![CDATA[ distance between horizontal slits (x)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[4]^Height</Name>
-						<Comment>
-							<![CDATA[ distance between vertical slits (y)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>astApertures^astApertures[4]^xOK</Name>
-						<Comment>
-							<![CDATA[ status of aperture, false if error or in motion]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>aVetoDevices</Name>
-						<Comment>
-							<![CDATA[ Stopper statuses ]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>xValidToggle</Name>
-						<Comment>
-							<![CDATA[ Toggle for watchdog]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>xValid</Name>
-						<Comment>
-							<![CDATA[ Beam parameter set is valid (if readback), or acknowledged (if request)]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>nCohortInt</Name>
-						<Comment>
-							<![CDATA[ Cohort index. Identifies which cohort this BP set was included in arbitration]]>
-						</Comment>
-					</SubVar>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="8">
+			<Vars VarGrpType="8" ContextId="2" AreaNo="36">
 				<Name>PlcTask Retains</Name>
 				<Var>
 					<Name>PMPS_GVL.SuccessfulPreemption</Name>
-					<Comment>
-						<![CDATA[ Any time BPTM applies a new BP request which is confirmed]]>
-					</Comment>
+					<Comment><![CDATA[ Any time BPTM applies a new BP request which is confirmed]]></Comment>
 					<Type>UDINT</Type>
 					<InOut>7</InOut>
 				</Var>
 				<Var>
 					<Name>PMPS_GVL.AccumulatedFF</Name>
-					<Comment>
-						<![CDATA[ Any time a FF occurs]]>
-					</Comment>
+					<Comment><![CDATA[ Any time a FF occurs]]></Comment>
 					<Type>UDINT</Type>
 					<InOut>7</InOut>
 				</Var>
@@ -6489,10 +3278,39 @@ External Setpoint Generation:
 					</OwnerB>
 				</OwnerA>
 			</UnrestoredVarLinks>
+			<Contexts>
+				<Context>
+					<Id NeedCalleeCall="true">0</Id>
+					<Name>SerialIO</Name>
+					<ManualConfig>
+						<OTCID>#x02010060</OTCID>
+					</ManualConfig>
+					<Priority>1</Priority>
+					<CycleTime>2000000</CycleTime>
+				</Context>
+				<Context>
+					<Id NeedCalleeCall="true">1</Id>
+					<Name>PiezoDriver</Name>
+					<ManualConfig>
+						<OTCID>#x02010080</OTCID>
+					</ManualConfig>
+					<Priority>3</Priority>
+					<CycleTime>1000000</CycleTime>
+				</Context>
+				<Context>
+					<Id NeedCalleeCall="true">2</Id>
+					<Name>PlcTask</Name>
+					<ManualConfig>
+						<OTCID>#x02010020</OTCID>
+					</ManualConfig>
+					<Priority>20</Priority>
+					<CycleTime>10000000</CycleTime>
+				</Context>
+			</Contexts>
 			<TaskPouOids>
 				<TaskPouOid Prio="1" OTCID="#x08502001"/>
-				<TaskPouOid Prio="20" OTCID="#x08502003"/>
 				<TaskPouOid Prio="3" OTCID="#x08502002"/>
+				<TaskPouOid Prio="20" OTCID="#x08502003"/>
 			</TaskPouOids>
 		</Instance>
 	</Project>
@@ -6502,12 +3320,12 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^GVL.gAmsNetIDEcatMaster1" VarB="InfoData^AmsNetId"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 13 (EL2008)">
-				<Link VarA="PlcTask Outputs^GVL.bXRT_M2_IN" VarB="Channel 2^Output"/>
-				<Link VarA="PlcTask Outputs^GVL.bXRT_M2_OUT" VarB="Channel 1^Output"/>
+				<Link VarA="PlcTask Outputs^GVL.bXRT_M2_IN" VarB="Channel 2^Output" Size="1"/>
+				<Link VarA="PlcTask Outputs^GVL.bXRT_M2_OUT" VarB="Channel 1^Output" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL1004_M1L3_STO">
-				<Link VarA="PlcTask Inputs^Main.MR1L3.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.MR1L3.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.MR1L3.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.MR1L3.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL3202-0010_MR1L3_1">
 				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
@@ -6579,32 +3397,32 @@ External Setpoint Generation:
 				<Link VarA="SerialIO Outputs^GVL_SerialIO.Serial_stComOut_MR1L3^D[9]" VarB="COM Outputs^Data Out 9" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL7041-1000_M1L3_Bender">
-				<Link VarA="PlcTask Inputs^Main.M6.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M6.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M6.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M6.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL7041-1000_M1L3_PitchCoarse">
-				<Link VarA="PlcTask Inputs^Main.M5.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M5.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M5.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M5.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL7041-1000_M1L3_Xdwn">
-				<Link VarA="PlcTask Inputs^Main.M4.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M4.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M4.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M4.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL7041-1000_M1L3_Xup">
-				<Link VarA="PlcTask Inputs^Main.M3.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M3.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M3.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M3.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL7041-1000_M1L3_Ydwn">
-				<Link VarA="PlcTask Inputs^Main.M2.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M2.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M2.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M2.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL7041-1000_M1L3_Yup">
-				<Link VarA="PlcTask Inputs^Main.M1.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M1.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M1.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M1.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL1004_M1L4_STO">
-				<Link VarA="PlcTask Inputs^Main.MR1L4.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.MR1L4.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.MR1L4.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.MR1L4.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL3202-0010_MR1L4_1">
 				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
@@ -6676,32 +3494,32 @@ External Setpoint Generation:
 				<Link VarA="SerialIO Outputs^GVL_SerialIO.Serial_stComOut_MR1L4^D[9]" VarB="COM Outputs^Data Out 9" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Bender">
-				<Link VarA="PlcTask Inputs^Main.M12.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M12.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M12.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M12.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_PitchCoarse">
-				<Link VarA="PlcTask Inputs^Main.M11.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M11.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M11.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M11.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Xdwn">
-				<Link VarA="PlcTask Inputs^Main.M10.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M10.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M10.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M10.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Xup">
-				<Link VarA="PlcTask Inputs^Main.M9.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M9.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M9.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M9.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Ydwn">
-				<Link VarA="PlcTask Inputs^Main.M8.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M8.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M8.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M8.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL7041-1000_M1L4_Yup">
-				<Link VarA="PlcTask Inputs^Main.M7.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M7.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M7.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M7.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL1004_M2L3_STO">
-				<Link VarA="PlcTask Inputs^Main.MR2L3.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.MR2L3.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.MR2L3.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.MR2L3.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL3202-0010_MR2L3_1">
 				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
@@ -6771,32 +3589,32 @@ External Setpoint Generation:
 				<Link VarA="SerialIO Outputs^GVL_SerialIO.Serial_stComOut_MR2L3^D[9]" VarB="COM Outputs^Data Out 9" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Bender">
-				<Link VarA="PlcTask Inputs^Main.M18.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M18.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M18.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M18.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_PitchCoarse">
-				<Link VarA="PlcTask Inputs^Main.M17.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M17.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M17.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M17.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Xdwn">
-				<Link VarA="PlcTask Inputs^Main.M16.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M16.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M16.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M16.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Xup">
-				<Link VarA="PlcTask Inputs^Main.M15.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M15.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M15.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M15.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Ydwn">
-				<Link VarA="PlcTask Inputs^Main.M14.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M14.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M14.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M14.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Yup">
-				<Link VarA="PlcTask Inputs^Main.M13.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M13.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M13.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M13.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 34 (EK1521-0010)^Term 23 (EK1501-0010)^PMPS_FFO">
-				<Link VarA="PlcTask Outputs^GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut" VarB="Channel 1^Output" AutoLink="true"/>
-				<Link VarA="PlcTask Outputs^GVL_PMPS.g_FastFaultOutput2.q_xFastFaultOut" VarB="Channel 2^Output" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut" VarB="Channel 1^Output" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Outputs^GVL_PMPS.g_FastFaultOutput2.q_xFastFaultOut" VarB="Channel 2^Output" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 34 (EK1521-0010)^Term 23 (EK1501-0010)^PMPS_PRE">
 				<Link VarA="PlcTask Inputs^GVL_PMPS.fbArbiterIO.i_stCurrentBP" VarB="IO Inputs^CurrentBP" AutoLink="true"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Changed lcls-twincat-optics from 0.4.1 -> 0.6.1 a 4024.12 compatible optics library version.
- rebuilt the project with twincat `Build 4024.12` and pinned.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PLC task count was found at 0 in the LFE PMPS Diagnostics screen. Investigation revealed a PLC project that would build with error: `Generating TMC failed! Object reference not set to an instance of an object`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This branch has been built into an IOC and run out of dev area and confirmed working.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Theres an optics plc meta data google sheet here: https://docs.google.com/spreadsheets/d/1AsE6Rr7B13iugeojyHwu_NMrbAkEo44SVXUBYZ15FaE/edit#gid=0 
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
