### PR TITLE
Re-Implement RTDs and fix Precision readout at the PLC level.

### DIFF
--- a/HOMS_XRT/HOMS_XRT.tsproj
+++ b/HOMS_XRT/HOMS_XRT.tsproj
@@ -2362,10 +2362,10 @@
 							<Box File="EL9505_M1L3_BenderLims.xti" Id="41">
 								<EtherCAT PortABoxInfo="#x01000028"/>
 							</Box>
-							<Box File="EL3202-0010_MR1L3_1.xti" Id="69">
+							<Box File="MR1L3-EL3202-0010-E13.xti" Id="69">
 								<EtherCAT PortABoxInfo="#x01000029"/>
 							</Box>
-							<Box File="EL3202-0010_MR1L3_2_3.xti" Id="70">
+							<Box File="MR1L3-EL3202-0010-E14.xti" Id="70">
 								<EtherCAT PortABoxInfo="#x01000045"/>
 							</Box>
 							<Box File="Term 42 (EL9011).xti" Id="42">
@@ -4493,10 +4493,10 @@
 							<Box File="EL9505_M1L4_BenderLims.xti" Id="28">
 								<EtherCAT PortABoxInfo="#x0100001b"/>
 							</Box>
-							<Box File="EL3202-0010_MR1L4_1.xti" Id="86">
+							<Box File="MR1L4-EL3202-0010-E13.xti" Id="86">
 								<EtherCAT PortABoxInfo="#x0100001c"/>
 							</Box>
-							<Box File="EL3202-0010_MR1L4_2_3.xti" Id="87">
+							<Box File="MR1L4-EL3202-0010-E14.xti" Id="87">
 								<EtherCAT PortABoxInfo="#x01000056"/>
 							</Box>
 							<Box File="Term 29 (EL9011).xti" Id="29">

--- a/HOMS_XRT/HOMS_XRT.tsproj
+++ b/HOMS_XRT/HOMS_XRT.tsproj
@@ -112,6 +112,7 @@
 				<Target BkhfOrder="VE2378134">
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<ManualSelect>{6952449D-F68C-49A2-ADE4-8639D85B33A4}</ManualSelect>
+					<LicenseDevice DongleHardwareId="2"/>
 				</Target>
 			</Licenses>
 			<Tasks>

--- a/HOMS_XRT/HOMS_XRT_PLC/GVLs/GVL_RTDS.TcGVL
+++ b/HOMS_XRT/HOMS_XRT_PLC/GVLs/GVL_RTDS.TcGVL
@@ -3,31 +3,99 @@
   <GVL Name="GVL_RTDS" Id="{0b62862d-8567-4022-be19-38483cd606a9}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL
-    // M2K4 BENDER RTDs
-
-    // M1L3 RTDs
-    {attribute 'TcLinkTo' := 'TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value'}
-    nM1L3_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value'}
-    nM1L3_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value'}
-    nM1L3_RTD_3 AT %I* : INT;
-
-    // M2L3 RTDs
-    {attribute 'TcLinkTo' := 'TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value'}
-    nM2L3_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value'}
-    nM2L3_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value'}
-    nM2L3_RTD_3 AT %I* : INT;
-
-    // M1L4 RTDs
-    {attribute 'TcLinkTo' := 'TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Value'}
-    nM1L4_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Value'}
-    nM1L4_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Value'}
-    nM1L4_RTD_3 AT %I* : INT;
+    // MR1L3 RTDs
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR1L3:HOMS:ENV:RTD:1
+        field: EGU C
+        io: i
+    '}
+    nMR1L3_Env_RTD_1 : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR1L3:HOMS:ENV:RTD:2
+        field: EGU C
+        io: i
+    '}
+    nMR1L3_Env_RTD_2 : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR1L3:HOMS:ENV:RTD:3
+        field: EGU C
+        io: i
+    '}
+    nMR1L3_Env_RTD_3 : FB_TempSensor;
+    // MR2L3 RTDs
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR2L3:HOMS:ENV:RTD:1
+        field: EGU C
+        io: i
+    '}
+    nMR2L3_Env_RTD_1 : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR2L3:HOMS:ENV:RTD:2
+        field: EGU C
+        io: i
+    '}
+    nMR2L3_Env_RTD_2 : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR2L3:HOMS:ENV:RTD:3
+        field: EGU C
+        io: i
+    '}
+    nMR2L3_Env_RTD_3 : FB_TempSensor;
+    // MR1L4 RTDs
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR1L4:HOMS:ENV:RTD:1
+        field: EGU C
+        io: i
+    '}
+    nMR1L4_Env_RTD_1 : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR1L4:HOMS:ENV:RTD:2
+        field: EGU C
+        io: i
+    '}
+    nMR1L4_Env_RTD_2 : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR1L4:HOMS:ENV:RTD:3
+        field: EGU C
+        io: i
+    '}
+    nMR1L4_Env_RTD_3 : FB_TempSensor;
 
 END_VAR]]></Declaration>
   </GVL>

--- a/HOMS_XRT/HOMS_XRT_PLC/GVLs/GVL_RTDS.TcGVL
+++ b/HOMS_XRT/HOMS_XRT_PLC/GVLs/GVL_RTDS.TcGVL
@@ -1,32 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
   <GVL Name="GVL_RTDS" Id="{0b62862d-8567-4022-be19-38483cd606a9}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL
     // M2K4 BENDER RTDs
 
     // M1L3 RTDs
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR1L3_1]^RTD Inputs Channel 1^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value'}
     nM1L3_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR1L3_2_3]^RTD Inputs Channel 1^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value'}
     nM1L3_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR1L3_2_3]^RTD Inputs Channel 2^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value'}
     nM1L3_RTD_3 AT %I* : INT;
 
     // M2L3 RTDs
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR2L3_1]^RTD Inputs Channel 1^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value'}
     nM2L3_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR2L3_2_3]^RTD Inputs Channel 1^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value'}
     nM2L3_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR2L3_2_3]^RTD Inputs Channel 2^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value'}
     nM2L3_RTD_3 AT %I* : INT;
 
     // M1L4 RTDs
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR1L4_1]^RTD Inputs Channel 1^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Value'}
     nM1L4_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR1L4_2_3]^RTD Inputs Channel 1^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Value'}
     nM1L4_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_MR1L4_2_3]^RTD Inputs Channel 2^Value'}
+    {attribute 'TcLinkTo' := 'TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Value'}
     nM1L4_RTD_3 AT %I* : INT;
 
 END_VAR]]></Declaration>

--- a/HOMS_XRT/HOMS_XRT_PLC/GVLs/GVL_RTDS.TcGVL
+++ b/HOMS_XRT/HOMS_XRT_PLC/GVLs/GVL_RTDS.TcGVL
@@ -13,7 +13,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR1L3_Env_RTD_1 : FB_TempSensor;
+    fbMR1L3_Env_RTD_1 : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
                               .bUnderrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
                               .bOverrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
@@ -23,7 +23,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR1L3_Env_RTD_2 : FB_TempSensor;
+    fbMR1L3_Env_RTD_2 : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
                               .bUnderrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
@@ -33,7 +33,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR1L3_Env_RTD_3 : FB_TempSensor;
+    fbMR1L3_Env_RTD_3 : FB_TempSensor;
     // MR2L3 RTDs
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
                               .bUnderrange := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
@@ -44,7 +44,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR2L3_Env_RTD_1 : FB_TempSensor;
+    fbMR2L3_Env_RTD_1 : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
                               .bUnderrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
                               .bOverrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
@@ -54,7 +54,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR2L3_Env_RTD_2 : FB_TempSensor;
+    fbMR2L3_Env_RTD_2 : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
                               .bUnderrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
@@ -64,7 +64,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR2L3_Env_RTD_3 : FB_TempSensor;
+    fbMR2L3_Env_RTD_3 : FB_TempSensor;
     // MR1L4 RTDs
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
                               .bUnderrange := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
@@ -75,7 +75,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR1L4_Env_RTD_1 : FB_TempSensor;
+    fbMR1L4_Env_RTD_1 : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
                               .bUnderrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
                               .bOverrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
@@ -85,7 +85,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR1L4_Env_RTD_2 : FB_TempSensor;
+    fbMR1L4_Env_RTD_2 : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
                               .bUnderrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
@@ -95,7 +95,7 @@ VAR_GLOBAL
         field: EGU C
         io: i
     '}
-    nMR1L4_Env_RTD_3 : FB_TempSensor;
+    fbMR1L4_Env_RTD_3 : FB_TempSensor;
 
 END_VAR]]></Declaration>
   </GVL>

--- a/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
+++ b/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{5EF6A122-29A6-3613-9D05-5DD1880F707A}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{83527180-D098-1D9E-93E6-F1F73CDF7849}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -54173,6 +54173,171 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
       </Hides>
     </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_TempSensor</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>fResolution</Name>
+        <Type>LREAL</Type>
+        <Comment> Resolution parameter from the Beckhoff docs. Default is 0.1 for 0.1 degree resolution</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0.1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTemp</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: TEMP
+        io: input
+        field: EGU C
+        field: PREC 2
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bConnected</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: CONN
+        io: input
+        field: ONAM Connected
+        field: ZNAM Disconnected
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUnderrange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bOverrange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iRaw</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{6782D19E-49E6-4E53-A280-FB39675852DF}" TcSmClass="TComPlcObjDef">
@@ -59782,85 +59947,6 @@ Beckhoff</Comment>
             <BitOffs>654431936</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_RTDS.nM1L3_RTD_1</Name>
-            <Comment> M2K4 BENDER RTDs
- M1L3 RTDs</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR1L3_1]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>654432032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_RTDS.nM1L3_RTD_2</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR1L3_2_3]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>654432048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_RTDS.nM1L3_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR1L3_2_3]^RTD Inputs Channel 2^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>654447200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_RTDS.nM2L3_RTD_1</Name>
-            <Comment> M2L3 RTDs</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR2L3_1]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>654447216</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>GVL_MR1L3.MR1L3_Pitch.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
             <BitSize>64</BitSize>
@@ -59958,100 +60044,544 @@ Beckhoff</Comment>
             <BitOffs>656399777</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_RTDS.nM2L3_RTD_2</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
             <Properties>
               <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR2L3_2_3]^RTD Inputs Channel 1^Value</Value>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
             </Properties>
-            <BitOffs>656534208</BitOffs>
+            <BitOffs>661483784</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_RTDS.nM2L3_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR2L3_2_3]^RTD Inputs Channel 2^Value</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
             </Properties>
-            <BitOffs>656534224</BitOffs>
+            <BitOffs>661483792</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_RTDS.nM1L4_RTD_1</Name>
-            <Comment> M1L4 RTDs</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR1L4_1]^RTD Inputs Channel 1^Value</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
             </Properties>
-            <BitOffs>656534240</BitOffs>
+            <BitOffs>661483800</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_RTDS.nM1L4_RTD_2</Name>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.iRaw</Name>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
               <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR1L4_2_3]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
             </Properties>
-            <BitOffs>656534256</BitOffs>
+            <BitOffs>661483808</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_RTDS.nM1L4_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
             <Properties>
               <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_MR1L4_2_3]^RTD Inputs Channel 2^Value</Value>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
+            </Properties>
+            <BitOffs>661484040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
               <Property>
-                <Name>TcVarGlobal</Name>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656534272</BitOffs>
+            <BitOffs>661484048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661484832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661485856</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -69611,159 +70141,6 @@ PMPS State Stage; bPowerSelf:=False</Comment>
             <BitOffs>646921728</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fM1L3_RTD_1</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1L3:HOMS:RTD:1
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM1L3_RTD_2</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1L3:HOMS:RTD:2
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM1L3_RTD_3</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1L3:HOMS:RTD:3
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM2L3_RTD_1</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2L3:HOMS:RTD:1
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM2L3_RTD_2</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2L3:HOMS:RTD:2
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM2L3_RTD_3</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2L3:HOMS:RTD:3
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM1L4_RTD_1</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1L4:HOMS:RTD:1
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM1L4_RTD_2</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1L4:HOMS:RTD:2
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fM1L4_RTD_3</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1L4:HOMS:RTD:3
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652706880</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_PMPS.nReq</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
@@ -71575,6 +71952,243 @@ PMPS State Stage; bPowerSelf:=False</Comment>
             </Properties>
             <BitOffs>656595872</BitOffs>
           </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_1</Name>
+            <Comment> MR1L3 RTDs</Comment>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1L3:HOMS:ENV:RTD:1
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661483584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_2</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1L3:HOMS:ENV:RTD:2
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661483840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L3_Env_RTD_3</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[MR1L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1L3:HOMS:ENV:RTD:3
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661484096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_1</Name>
+            <Comment> MR2L3 RTDs</Comment>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR2L3-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR2L3:HOMS:ENV:RTD:1
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661484352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_2</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR2L3:HOMS:ENV:RTD:2
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661484608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR2L3_Env_RTD_3</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[MR2L3-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR2L3:HOMS:ENV:RTD:3
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661484864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_1</Name>
+            <Comment> MR1L4 RTDs</Comment>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L4-EL3202-0010-E13]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1L4:HOMS:ENV:RTD:1
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661485120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_2</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1L4:HOMS:ENV:RTD:2
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661485376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_RTDS.fbMR1L4_Env_RTD_3</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[MR1L4-EL3202-0010-E14]^RTD Inputs Channel 2^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1L4:HOMS:ENV:RTD:3
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>661485632</BitOffs>
+          </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">36</AreaNo>
@@ -71660,7 +72274,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-06-21T11:18:05</Value>
+          <Value>2023-08-04T16:08:27</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/HOMS_XRT/HOMS_XRT_PLC/POUs/MAIN.TcPOU
+++ b/HOMS_XRT/HOMS_XRT_PLC/POUs/MAIN.TcPOU
@@ -794,17 +794,17 @@ PRG_PMPS();
 // Logging
 fbLogHandler();
 
-GVL_RTDS.fbMR1L3_Env_RTD_1();
-GVL_RTDS.fbMR1L3_Env_RTD_2();
-GVL_RTDS.fbMR1L3_Env_RTD_3();
+GVL_RTDS.fbMR1L3_Env_RTD_1(fResolution:=0.01);
+GVL_RTDS.fbMR1L3_Env_RTD_2(fResolution:=0.01);
+GVL_RTDS.fbMR1L3_Env_RTD_3(fResolution:=0.01);
 
-GVL_RTDS.fbMR2L3_Env_RTD_1();
-GVL_RTDS.fbMR2L3_Env_RTD_2();
-GVL_RTDS.fbMR2L3_Env_RTD_3();
+GVL_RTDS.fbMR2L3_Env_RTD_1(fResolution:=0.01);
+GVL_RTDS.fbMR2L3_Env_RTD_2(fResolution:=0.01);
+GVL_RTDS.fbMR2L3_Env_RTD_3(fResolution:=0.01);
 
-GVL_RTDS.fbMR1L4_Env_RTD_1();
-GVL_RTDS.fbMR1L4_Env_RTD_2();
-GVL_RTDS.fbMR1L4_Env_RTD_3();
+GVL_RTDS.fbMR1L4_Env_RTD_1(fResolution:=0.01);
+GVL_RTDS.fbMR1L4_Env_RTD_2(fResolution:=0.01);
+GVL_RTDS.fbMR1L4_Env_RTD_3(fResolution:=0.01);
 
 
 

--- a/HOMS_XRT/HOMS_XRT_PLC/POUs/MAIN.TcPOU
+++ b/HOMS_XRT/HOMS_XRT_PLC/POUs/MAIN.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
   <POU Name="Main" Id="{ea0bf136-bb68-48b6-99e0-4530d55408e2}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM Main
 VAR
@@ -520,70 +520,6 @@ VAR
 
     // Logging
     fbLogHandler : FB_LogHandler;
-    {attribute 'pytmc' := '
-        pv: MR1L3:HOMS:RTD:1
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM1L3_RTD_1 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR1L3:HOMS:RTD:2
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM1L3_RTD_2 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR1L3:HOMS:RTD:3
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM1L3_RTD_3 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR2L3:HOMS:RTD:1
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM2L3_RTD_1 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR2L3:HOMS:RTD:2
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM2L3_RTD_2 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR2L3:HOMS:RTD:3
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM2L3_RTD_3 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR1L4:HOMS:RTD:1
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM1L4_RTD_1 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR1L4:HOMS:RTD:2
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM1L4_RTD_2 : REAL;
-    {attribute 'pytmc' := '
-        pv: MR1L4:HOMS:RTD:3
-        field: ASLO 0.1
-        field: EGU C
-        io: i
-    '}
-    fM1L4_RTD_3 : REAL;
-
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -858,17 +794,21 @@ PRG_PMPS();
 // Logging
 fbLogHandler();
 
-fM1L3_RTD_1 := INT_TO_REAL(GVL_RTDS.nM1L3_RTD_1);
-fM1L3_RTD_2 := INT_TO_REAL(GVL_RTDS.nM1L3_RTD_2);
-fM1L3_RTD_3 := INT_TO_REAL(GVL_RTDS.nM1L3_RTD_3);
+GVL_RTDS.fbMR1L3_Env_RTD_1();
+GVL_RTDS.fbMR1L3_Env_RTD_2();
+GVL_RTDS.fbMR1L3_Env_RTD_3();
 
-fM2L3_RTD_1 := INT_TO_REAL(GVL_RTDS.nM2L3_RTD_1);
-fM2L3_RTD_2 := INT_TO_REAL(GVL_RTDS.nM2L3_RTD_2);
-fM2L3_RTD_3 := INT_TO_REAL(GVL_RTDS.nM2L3_RTD_3);
+GVL_RTDS.fbMR2L3_Env_RTD_1();
+GVL_RTDS.fbMR2L3_Env_RTD_2();
+GVL_RTDS.fbMR2L3_Env_RTD_3();
 
-fM1L4_RTD_1 := INT_TO_REAL(GVL_RTDS.nM1L4_RTD_1);
-fM1L4_RTD_2 := INT_TO_REAL(GVL_RTDS.nM1L4_RTD_2);
-fM1L4_RTD_3 := INT_TO_REAL(GVL_RTDS.nM1L4_RTD_3);]]></ST>
+GVL_RTDS.fbMR1L4_Env_RTD_1();
+GVL_RTDS.fbMR1L4_Env_RTD_2();
+GVL_RTDS.fbMR1L4_Env_RTD_3();
+
+
+
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L3/MR1L3-EL3202-0010-E13.xti
+++ b/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L3/MR1L3-EL3202-0010-E13.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CFlbTermDef" SubType="9099">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>
@@ -14,7 +14,7 @@
 	<ImageDatas>
 		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
 	</ImageDatas>
-	<Box Id="86" BoxType="9099" BoxFlags="#x00000020">
+	<Box Id="69" BoxType="9099" BoxFlags="#x00000020">
 		<Name>__FILENAME__</Name>
 		<ImageId>1000</ImageId>
 		<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="3" FoeType="1" VendorId="#x00000002" ProductCode="#x0c823052" RevisionNo="#x0016000a" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL3202-0010 2Ch. Ana. Input PT100 (RTD), High Precision" Desc="EL3202-0010">

--- a/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L3/MR1L3-EL3202-0010-E14.xti
+++ b/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L3/MR1L3-EL3202-0010-E14.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CFlbTermDef" SubType="9099">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>
@@ -14,7 +14,7 @@
 	<ImageDatas>
 		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
 	</ImageDatas>
-	<Box Id="87" BoxType="9099" BoxFlags="#x00000020">
+	<Box Id="70" BoxType="9099" BoxFlags="#x00000020">
 		<Name>__FILENAME__</Name>
 		<ImageId>1000</ImageId>
 		<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="3" FoeType="1" VendorId="#x00000002" ProductCode="#x0c823052" RevisionNo="#x0016000a" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL3202-0010 2Ch. Ana. Input PT100 (RTD), High Precision" Desc="EL3202-0010">

--- a/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L4/MR1L4-EL3202-0010-E13.xti
+++ b/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L4/MR1L4-EL3202-0010-E13.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CFlbTermDef" SubType="9099">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>
@@ -14,7 +14,7 @@
 	<ImageDatas>
 		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
 	</ImageDatas>
-	<Box Id="100" BoxType="9099" BoxFlags="#x00000020">
+	<Box Id="86" BoxType="9099" BoxFlags="#x00000020">
 		<Name>__FILENAME__</Name>
 		<ImageId>1000</ImageId>
 		<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="3" FoeType="1" VendorId="#x00000002" ProductCode="#x0c823052" RevisionNo="#x0016000a" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL3202-0010 2Ch. Ana. Input PT100 (RTD), High Precision" Desc="EL3202-0010">

--- a/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L4/MR1L4-EL3202-0010-E14.xti
+++ b/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 14 (EK1122)/EK1100_M1L4/MR1L4-EL3202-0010-E14.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CFlbTermDef" SubType="9099">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>
@@ -14,7 +14,7 @@
 	<ImageDatas>
 		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
 	</ImageDatas>
-	<Box Id="69" BoxType="9099" BoxFlags="#x00000020">
+	<Box Id="87" BoxType="9099" BoxFlags="#x00000020">
 		<Name>__FILENAME__</Name>
 		<ImageId>1000</ImageId>
 		<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="3" FoeType="1" VendorId="#x00000002" ProductCode="#x0c823052" RevisionNo="#x0016000a" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL3202-0010 2Ch. Ana. Input PT100 (RTD), High Precision" Desc="EL3202-0010">

--- a/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 2 (EK1122)/EK1100_M2L3.xti
+++ b/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 2 (EK1122)/EK1100_M2L3.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CFlbTermDef" SubType="9099">
 	<ImageDatas>
 		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000bfff00bfffc0c0c0808080c0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000bfff00bfffc0c0c0808080c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000bfff00bfffc0c0c0808080c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080c0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000bfff00bfffc0c0c0808080c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000bfff00bfffc0c0c0808080c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000bfff00bfffc0c0c0808080c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
 	</ImageDatas>
@@ -43,10 +43,10 @@
 		<Box File="EL9505_M2L3_BenderLims.xti" Id="55">
 			<EtherCAT PortABoxInfo="#x01000036"/>
 		</Box>
-		<Box File="EL3202-0010_MR2L3_1.xti" Id="100">
+		<Box File="MR2L3-EL3202-0010-E13.xti" Id="100">
 			<EtherCAT PortABoxInfo="#x01000037"/>
 		</Box>
-		<Box File="EL3202-0010_MR2L3_2_3.xti" Id="101">
+		<Box File="MR2L3-EL3202-0010-E14.xti" Id="101">
 			<EtherCAT PortABoxInfo="#x01000064"/>
 		</Box>
 		<Box File="Term 56 (EL9011).xti" Id="56">

--- a/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 2 (EK1122)/EK1100_M2L3/MR2L3-EL3202-0010-E13.xti
+++ b/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 2 (EK1122)/EK1100_M2L3/MR2L3-EL3202-0010-E13.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CFlbTermDef" SubType="9099">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>
@@ -14,7 +14,7 @@
 	<ImageDatas>
 		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
 	</ImageDatas>
-	<Box Id="70" BoxType="9099" BoxFlags="#x00000020">
+	<Box Id="100" BoxType="9099" BoxFlags="#x00000020">
 		<Name>__FILENAME__</Name>
 		<ImageId>1000</ImageId>
 		<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="3" FoeType="1" VendorId="#x00000002" ProductCode="#x0c823052" RevisionNo="#x0016000a" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL3202-0010 2Ch. Ana. Input PT100 (RTD), High Precision" Desc="EL3202-0010">

--- a/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 2 (EK1122)/EK1100_M2L3/MR2L3-EL3202-0010-E14.xti
+++ b/HOMS_XRT/_Config/IO/HOMS/Term 1 (EK1200)/Term 2 (EK1122)/EK1100_M2L3/MR2L3-EL3202-0010-E14.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CFlbTermDef" SubType="9099">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>

--- a/HOMS_XRT/_Config/PLC/HOMS_XRT_PLC.xti
+++ b/HOMS_XRT/_Config/PLC/HOMS_XRT_PLC.xti
@@ -2636,25 +2636,6 @@ External Setpoint Generation:
 					<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
 				</Var>
 				<Var>
-					<Name>GVL_RTDS.nM1L3_RTD_1</Name>
-					<Comment><![CDATA[ M2K4 BENDER RTDs
- M1L3 RTDs]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_RTDS.nM1L3_RTD_2</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_RTDS.nM1L3_RTD_3</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_RTDS.nM2L3_RTD_1</Name>
-					<Comment><![CDATA[ M2L3 RTDs]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_MR1L3.MR1L3_Pitch.diEncCnt</Name>
 					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
@@ -2682,24 +2663,147 @@ External Setpoint Generation:
 					<Type>BIT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_RTDS.nM2L3_RTD_2</Name>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_1.iRaw</Name>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_RTDS.nM2L3_RTD_3</Name>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_2.iRaw</Name>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_RTDS.nM1L4_RTD_1</Name>
-					<Comment><![CDATA[ M1L4 RTDs]]></Comment>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L3_Env_RTD_3.iRaw</Name>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_RTDS.nM1L4_RTD_2</Name>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_1.iRaw</Name>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_RTDS.nM1L4_RTD_3</Name>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_2.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR2L3_Env_RTD_3.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_1.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_2.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_RTDS.fbMR1L4_Env_RTD_3.iRaw</Name>
 					<Type>INT</Type>
 				</Var>
 			</Vars>
@@ -3414,11 +3518,20 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.M1.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^MR1L3-EL3202-0010-E13">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_1.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_1.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_1.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_1.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^MR1L3-EL3202-0010-E14">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_2.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_2.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_2.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_2.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_3.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_3.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_3.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L3_Env_RTD_3.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL1004_M1L4_STO">
 				<Link VarA="PlcTask Inputs^Main.MR1L4.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
@@ -3511,11 +3624,20 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.M7.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^MR1L4-EL3202-0010-E13">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_1.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_1.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_1.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_1.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^MR1L4-EL3202-0010-E14">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_2.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_2.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_2.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_2.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_3.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_3.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_3.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR1L4_Env_RTD_3.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL1004_M2L3_STO">
 				<Link VarA="PlcTask Inputs^Main.MR2L3.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
@@ -3606,11 +3728,20 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.M13.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^MR2L3-EL3202-0010-E13">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_1.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_1.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_1.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_1.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^MR2L3-EL3202-0010-E14">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_2.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_2.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_2.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_2.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_3.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_3.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_3.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.fbMR2L3_Env_RTD_3.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 34 (EK1521-0010)^Term 23 (EK1501-0010)^PMPS_FFO">
 				<Link VarA="PlcTask Outputs^GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut" VarB="Channel 1^Output" AutoLink="true" Size="1"/>

--- a/HOMS_XRT/_Config/PLC/HOMS_XRT_PLC.xti
+++ b/HOMS_XRT/_Config/PLC/HOMS_XRT_PLC.xti
@@ -3327,13 +3327,6 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.MR1L3.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.MR1L3.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
-			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL3202-0010_MR1L3_1">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-			</OwnerB>
-			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL3202-0010_MR1L3_2_3">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
-			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^EL5042_M1L3_PitchBender">
 				<Link VarA="PlcTask Inputs^GVL_MR1L3.MR1L3_Pitch.diEncCnt" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^Main.M5.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -3420,16 +3413,16 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.M1.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M1.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
+			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^MR1L3-EL3202-0010-E13">
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L3^MR1L3-EL3202-0010-E14">
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L3_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL1004_M1L4_STO">
 				<Link VarA="PlcTask Inputs^Main.MR1L4.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.MR1L4.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
-			</OwnerB>
-			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL3202-0010_MR1L4_1">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-			</OwnerB>
-			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL3202-0010_MR1L4_2_3">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^EL5042_M1L4_PitchBender">
 				<Link VarA="PlcTask Inputs^GVL_MR1L4.MR1L4_Pitch.diEncCnt" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -3517,16 +3510,16 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.M7.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M7.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
+			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^MR1L4-EL3202-0010-E13">
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 14 (EK1122)^EK1100_M1L4^MR1L4-EL3202-0010-E14">
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM1L4_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL1004_M2L3_STO">
 				<Link VarA="PlcTask Inputs^Main.MR2L3.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.MR2L3.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
-			</OwnerB>
-			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL3202-0010_MR2L3_1">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-			</OwnerB>
-			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL3202-0010_MR2L3_2_3">
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL5042_M2L3_PitchBender">
 				<Link VarA="PlcTask Inputs^Main.M17.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -3611,6 +3604,13 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^EL7041-1000_M2L3_Yup">
 				<Link VarA="PlcTask Inputs^Main.M13.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M13.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
+			</OwnerB>
+			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^MR2L3-EL3202-0010-E13">
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 2 (EK1122)^EK1100_M2L3^MR2L3-EL3202-0010-E14">
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^GVL_RTDS.nM2L3_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^HOMS^Term 1 (EK1200)^Term 34 (EK1521-0010)^Term 23 (EK1501-0010)^PMPS_FFO">
 				<Link VarA="PlcTask Outputs^GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut" VarB="Channel 1^Output" AutoLink="true" Size="1"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Re-Implemented RTDs in the XRT HOMS enclosures using `FB_TempSensor`.
<!--- Describe your changes in detail -->

## Motivation and Context
RTDs were reading out to 1/10th C but should have been 1/100th C
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Sensors have been collecting data that can be view to the correct precision on Grafana here:
- https://pswww.slac.stanford.edu/ctl/grafana/d/OBn9EbR7z/xrt-mirrors?orgId=1&from=now-90d&to=now
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to fixed versions and not ``Always Newest``
- [x] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
