### PR TITLE
BUG: LCLS-General place holder not set

### DIFF
--- a/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.plcproj
+++ b/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.plcproj
@@ -358,6 +358,9 @@
     </PlaceholderReference>
   </ItemGroup>
   <ItemGroup>
+    <PlaceholderResolution Include="LCLS General">
+      <Resolution>LCLS General, 2.8.2 (SLAC)</Resolution>
+    </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 1.8.0 (SLAC)</Resolution>
     </PlaceholderResolution>

--- a/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
+++ b/HOMS_XRT/HOMS_XRT_PLC/HOMS_XRT_PLC.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{F6EF02E4-586A-7882-DCD8-0494F40514D5}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{31D07D8A-DAC7-CBFE-D20E-68DA211E4BA0}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -3838,31 +3838,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82099932</GetCodeOffs>
+        <GetCodeOffs>82089184</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82099968</GetCodeOffs>
+        <GetCodeOffs>82089220</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82099976</GetCodeOffs>
+        <GetCodeOffs>82089228</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82099956</GetCodeOffs>
+        <GetCodeOffs>82089208</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82099972</GetCodeOffs>
+        <GetCodeOffs>82089224</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -5146,15 +5146,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82099868</GetCodeOffs>
-        <SetCodeOffs>82099892</SetCodeOffs>
+        <GetCodeOffs>82089120</GetCodeOffs>
+        <SetCodeOffs>82089144</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82099908</GetCodeOffs>
-        <SetCodeOffs>82099920</SetCodeOffs>
+        <GetCodeOffs>82089160</GetCodeOffs>
+        <SetCodeOffs>82089172</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>ExtendName</Name>
@@ -5430,37 +5430,37 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>82100024</GetCodeOffs>
+        <GetCodeOffs>82089276</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82100004</GetCodeOffs>
+        <GetCodeOffs>82089256</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82100092</GetCodeOffs>
+        <GetCodeOffs>82089344</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82100096</GetCodeOffs>
+        <GetCodeOffs>82089348</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82100052</GetCodeOffs>
+        <GetCodeOffs>82089304</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82100100</GetCodeOffs>
+        <GetCodeOffs>82089352</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -6096,7 +6096,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>82100128</GetCodeOffs>
+        <GetCodeOffs>82089380</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -15922,461 +15922,6 @@
         <BitSize>32</BitSize>
         <BitOffs>2912</BitOffs>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">ST_System</Name>
-      <Comment>Defacto system structure, must be included in all projects</Comment>
-      <BitSize>40</BitSize>
-      <SubItem>
-        <Name>xSwAlmRst</Name>
-        <Type>BOOL</Type>
-        <Comment> Global Alarm Reset - EPICS Command </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xAtVacuum</Name>
-        <Type>BOOL</Type>
-        <Comment> System At Vacuum </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFirstScan</Name>
-        <Type>BOOL</Type>
-        <Comment> This boolean is true for the first scan, and is false thereafter, use for initialization of stuff </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment>This bit is set when using the override features of the system</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>24</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xIOState</Name>
-        <Type>BOOL</Type>
-        <Comment> ECat Bus Health </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>analysis</Name>
-          <Value>-33</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">E_Subsystem</Name>
-      <BitSize>16</BitSize>
-      <BaseType>WORD</BaseType>
-      <Comment>LCLS Defined subsystems, make sure these correspond with casSubsystems in FB_LogMessage</Comment>
-      <EnumInfo>
-        <Text>NILVALUE</Text>
-        <Enum>0</Enum>
-        <Comment>Undefined system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>VACUUM</Text>
-        <Enum>1</Enum>
-        <Comment>Vacuum control system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MPS</Text>
-        <Enum>2</Enum>
-        <Comment>Machine protection system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MOTION</Text>
-        <Enum>3</Enum>
-        <Comment>Motion control systems</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FIELDBUS</Text>
-        <Enum>4</Enum>
-        <Comment>EtherCAT networks</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>SDS</Text>
-        <Enum>5</Enum>
-        <Comment>Sample delivery system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OPTICS</Text>
-        <Enum>6</Enum>
-        <Comment>Optics control system</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Name>
-      <BitSize>81984</BitSize>
-      <SubItem>
-        <Name>sMsg</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <Comment> Message to send</Comment>
-        <BitSize>2048</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eSevr</Name>
-        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>2080</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eSubsystem</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">E_Subsystem</Type>
-        <Comment> Subsystem</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>2096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sJson</Name>
-        <Type>STRING(7000)</Type>
-        <Comment> JSON to add to the message</Comment>
-        <BitSize>56008</BitSize>
-        <BitOffs>2112</BitOffs>
-        <Default>
-          <String>{}</String>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nMinTimeViolationAcceptable</Name>
-        <Type>INT</Type>
-        <Comment> How many times the min. time can be violated before the CB trips</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>58128</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nLocalTripThreshold</Name>
-        <Type>TIME</Type>
-        <Comment> Minimum time between calls allowed, pairs with nMinTimeViolationAcceptable</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>58144</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTrickleTripThreshold</Name>
-        <Type>TIME</Type>
-        <Comment> Trickle trip, activated by global threshold, should be &gt;&gt; LocalTripThreshold</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>58176</BitOffs>
-        <Default>
-          <Value>100</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTripResetPeriod</Name>
-        <Type>TIME</Type>
-        <Comment> Time for auto-reset</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>58208</BitOffs>
-        <Default>
-          <Value>600000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableAutoReset</Name>
-        <Type>BOOL</Type>
-        <Comment>Enable circuit breaker auto-reset (true by default)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>58240</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bInitialized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>58248</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bInitFailed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>58256</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>sSubsystemSource</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>58264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMessage</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcMessage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>58912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMessages</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>5</Elements>
-        </ArrayInfo>
-        <BitSize>17440</BitSize>
-        <BitOffs>58944</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbSource</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
-        <BitSize>2848</BitSize>
-        <BitOffs>76384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ipResultMessage</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>79232</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>hr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>79264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>hrLastInternalError</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>79296</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eTraceLevel</Name>
-        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>79328</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCall</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>79344</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>sPath</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>79352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>noinit</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTimesViolated</Name>
-        <Type>INT</Type>
-        <Comment>////////////////////////////</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>81408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LastCallTime</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CurrentCallTime</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DeltaSinceLastCall</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>WhenTripsCleared</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftTrippedReleased</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81728</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLocalTrickleTripped</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>81792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLocalTripped</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>81800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bTripped</Name>
-        <Type>BOOL</Type>
-        <Comment> Won't emit messages if true</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>81808</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-            pv: Tripped
-            io: i
-            field: DESC Log message FB tripped
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bResetBreaker</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>81816</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-            pv: Reset
-            io: o
-            field: DESC Rising-edge reset of trip
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtResetBreaker</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81824</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTripped</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81888</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>CircuitBreaker</Name>
-      </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>reflection</Name>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">PE_Ranges</Name>
@@ -31884,7 +31429,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>fbLogMessage</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
@@ -33755,7 +33300,7 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">FB_DataBuffer</Name>
+      <Name Namespace="LCLS_General">FB_DataBuffer</Name>
       <BitSize>288</BitSize>
       <SubItem>
         <Name>bExecute</Name>
@@ -33890,7 +33435,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">FB_LREALBuffer</Name>
+      <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
       <BitSize>128512</BitSize>
       <SubItem>
         <Name>bExecute</Name>
@@ -33958,7 +33503,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>fbDataBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_DataBuffer</Type>
+        <Type Namespace="LCLS_General">FB_DataBuffer</Type>
         <BitSize>288</BitSize>
         <BitOffs>128192</BitOffs>
       </SubItem>
@@ -33995,8 +33540,8 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">FB_BasicStats</Name>
-      <BitSize>1024</BitSize>
+      <Name Namespace="LCLS_General">FB_BasicStats</Name>
+      <BitSize>896</BitSize>
       <SubItem>
         <Name>aSignal</Name>
         <Type PointerTo="1">LREAL</Type>
@@ -34196,31 +33741,11 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fRMS</Name>
-        <Type>LREAL</Type>
-        <Comment> RMS of all values in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:RMS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
         <Name>bValid</Name>
         <Type>BOOL</Type>
         <Comment> True if the other outputs are valid</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>512</BitOffs>
+        <BitOffs>448</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -34239,43 +33764,37 @@ External Setpoint Generation:
         <Name>rTrig</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>544</BitOffs>
+        <BitOffs>480</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nIndex</Name>
         <Type>DINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>608</BitOffs>
+        <BitOffs>544</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nElemsSeen</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>640</BitOffs>
+        <BitOffs>576</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fSum</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fRMSSum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
+        <BitOffs>640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fVarianceSum</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>704</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fVarianceMean</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>768</BitOffs>
       </SubItem>
       <Method>
         <Name>__GetInterfaceReference</Name>
@@ -34311,7 +33830,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_optics">FB_HomsStats</Name>
-      <BitSize>450752</BitSize>
+      <BitSize>450496</BitSize>
       <SubItem>
         <Name>homs</Name>
         <Type Namespace="lcls_twincat_optics">DUT_HOMS</Type>
@@ -34362,37 +33881,37 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>fbDataYGantryDiff</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LREALBuffer</Type>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <Comment> YGantry Data Acquisition FB</Comment>
         <BitSize>128512</BitSize>
         <BitOffs>63360</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbDataXGantryDiff</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LREALBuffer</Type>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <Comment> XGantry Data Acquisition FB</Comment>
         <BitSize>128512</BitSize>
         <BitOffs>191872</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbYGantryStats</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_BasicStats</Type>
+        <Type Namespace="LCLS_General">FB_BasicStats</Type>
         <Comment> Calculate mean/standard deviation of YGantryDiff</Comment>
-        <BitSize>1024</BitSize>
+        <BitSize>896</BitSize>
         <BitOffs>320384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbXGantryStats</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_BasicStats</Type>
+        <Type Namespace="LCLS_General">FB_BasicStats</Type>
         <Comment> Calculate mean/standard deviation of XGantryDiff</Comment>
-        <BitSize>1024</BitSize>
-        <BitOffs>321408</BitOffs>
+        <BitSize>896</BitSize>
+        <BitOffs>321280</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fYGantryDiffMean</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>322432</BitOffs>
+        <BitOffs>322176</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34407,7 +33926,7 @@ External Setpoint Generation:
         <Name>fYGantryDiffStDev</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>322496</BitOffs>
+        <BitOffs>322240</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34422,7 +33941,7 @@ External Setpoint Generation:
         <Name>fXGantryDiffMean</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>322560</BitOffs>
+        <BitOffs>322304</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34437,7 +33956,7 @@ External Setpoint Generation:
         <Name>fXGantryDiffStDev</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>322624</BitOffs>
+        <BitOffs>322368</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34452,7 +33971,7 @@ External Setpoint Generation:
         <Name>bNewEncArray</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>322688</BitOffs>
+        <BitOffs>322432</BitOffs>
       </SubItem>
       <SubItem>
         <Name>aYGantryDiff</Name>
@@ -34462,7 +33981,7 @@ External Setpoint Generation:
           <Elements>1000</Elements>
         </ArrayInfo>
         <BitSize>64000</BitSize>
-        <BitOffs>322752</BitOffs>
+        <BitOffs>322496</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34481,7 +34000,7 @@ External Setpoint Generation:
           <Elements>1000</Elements>
         </ArrayInfo>
         <BitSize>64000</BitSize>
-        <BitOffs>386752</BitOffs>
+        <BitOffs>386496</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34526,7 +34045,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_optics">FB_RMSWatch</Name>
-      <BitSize>387008</BitSize>
+      <BitSize>386880</BitSize>
       <SubItem>
         <Name>fMaxRMSError</Name>
         <Type>LREAL</Type>
@@ -34609,14 +34128,14 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>fbDataEncPos</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LREALBuffer</Type>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <Comment> ActPos Data Acquisition FB</Comment>
         <BitSize>128512</BitSize>
         <BitOffs>512</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbDataSetPos</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LREALBuffer</Type>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <Comment> SetPos Data Acquisition FB</Comment>
         <BitSize>128512</BitSize>
         <BitOffs>129024</BitOffs>
@@ -34639,16 +34158,16 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>fbStats</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_BasicStats</Type>
+        <Type Namespace="LCLS_General">FB_BasicStats</Type>
         <Comment> Calculate mean/standard deviation of ActPos</Comment>
-        <BitSize>1024</BitSize>
+        <BitSize>896</BitSize>
         <BitOffs>257600</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fEncMean</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>258624</BitOffs>
+        <BitOffs>258496</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34663,7 +34182,7 @@ External Setpoint Generation:
         <Name>fEncStDev</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>258688</BitOffs>
+        <BitOffs>258560</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34678,7 +34197,7 @@ External Setpoint Generation:
         <Name>fCurrRMSError</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>258752</BitOffs>
+        <BitOffs>258624</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -34696,14 +34215,14 @@ External Setpoint Generation:
         <Name>nIndex</Name>
         <Type>DINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>258816</BitOffs>
+        <BitOffs>258688</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fSum</Name>
         <Type>LREAL</Type>
         <Comment> Just for calculating rms</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>258880</BitOffs>
+        <BitOffs>258752</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -34712,7 +34231,7 @@ External Setpoint Generation:
         <Name>fDiff</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>258944</BitOffs>
+        <BitOffs>258816</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -34725,7 +34244,7 @@ External Setpoint Generation:
           <Elements>1000</Elements>
         </ArrayInfo>
         <BitSize>64000</BitSize>
-        <BitOffs>259008</BitOffs>
+        <BitOffs>258880</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34744,7 +34263,7 @@ External Setpoint Generation:
           <Elements>1000</Elements>
         </ArrayInfo>
         <BitSize>64000</BitSize>
-        <BitOffs>323008</BitOffs>
+        <BitOffs>322880</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -34788,7 +34307,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">FB_Index</Name>
+      <Name Namespace="LCLS_General">FB_Index</Name>
       <Comment> Index FB
 A. Wallace 2016-9-3
 
@@ -34917,7 +34436,7 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.LCLS_General">ST_FbDiagnostics</Name>
+      <Name Namespace="LCLS_General">ST_FbDiagnostics</Name>
       <Comment>Stuff to log messages within function blocks</Comment>
       <BitSize>48896</BitSize>
       <SubItem>
@@ -34933,7 +34452,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>resultIdx</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_Index</Type>
+        <Type Namespace="LCLS_General">FB_Index</Type>
         <Comment>Incrementer, included here to facilitate using asResults</Comment>
         <BitSize>96</BitSize>
         <BitOffs>40960</BitOffs>
@@ -37774,7 +37293,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stDiag</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">ST_FbDiagnostics</Type>
+        <Type Namespace="LCLS_General">ST_FbDiagnostics</Type>
         <Comment> Logging</Comment>
         <BitSize>48896</BitSize>
         <BitOffs>224</BitOffs>
@@ -39461,7 +38980,7 @@ Use this thing to have a simple indexer with rollover.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>82105004</GetCodeOffs>
+        <GetCodeOffs>82094224</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="45">__getnTimestamp</Name>
@@ -41442,31 +40961,31 @@ Use this thing to have a simple indexer with rollover.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82104556</GetCodeOffs>
+        <GetCodeOffs>82093776</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>82104600</GetCodeOffs>
+        <GetCodeOffs>82093820</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82104564</GetCodeOffs>
+        <GetCodeOffs>82093784</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>82104588</GetCodeOffs>
+        <GetCodeOffs>82093808</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>82104608</GetCodeOffs>
+        <GetCodeOffs>82093828</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -47058,19 +46577,19 @@ These features efficiently address the addition, removal, and verification of be
       </SubItem>
       <SubItem>
         <Name>__FB_ARBITER__GETARBITRATEDBP__FBLOGMESSAGE</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>228672</BitOffs>
       </SubItem>
       <SubItem>
         <Name>__FB_ARBITER__ADDREQUEST__FBLOG</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>310656</BitOffs>
       </SubItem>
       <SubItem>
         <Name>__FB_ARBITER__REMOVEREQUEST__FBLOG</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>392640</BitOffs>
       </SubItem>
@@ -47208,7 +46727,7 @@ ELSE:
         </Local>
         <Local>
           <Name>fbLogMessage</Name>
-          <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
           <BitSize>81984</BitSize>
           <Properties>
             <Property>
@@ -47296,7 +46815,7 @@ ELSE:
         </Local>
         <Local>
           <Name>fbLog</Name>
-          <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
           <BitSize>81984</BitSize>
           <Properties>
             <Property>
@@ -47318,7 +46837,7 @@ ELSE:
         </Parameter>
         <Local>
           <Name>fbLog</Name>
-          <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
           <BitSize>81984</BitSize>
           <Properties>
             <Property>
@@ -49671,7 +49190,7 @@ ELSE:
       </SubItem>
       <SubItem>
         <Name>fbLogger</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>413056</BitOffs>
         <Default>
@@ -51026,7 +50545,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>LogBuffIdx</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_Index</Type>
+        <Type Namespace="LCLS_General">FB_Index</Type>
         <BitSize>96</BitSize>
         <BitOffs>34752</BitOffs>
         <Default>
@@ -53074,7 +52593,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>fbLog</Name>
-        <Type Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</Type>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
         <BitSize>81984</BitSize>
         <BitOffs>56704</BitOffs>
       </SubItem>
@@ -54972,7 +54491,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656622080</BitOffs>
+            <BitOffs>656536384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_MR1L4</Name>
@@ -55013,7 +54532,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656622464</BitOffs>
+            <BitOffs>656536768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_MR2L3</Name>
@@ -55055,7 +54574,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656622848</BitOffs>
+            <BitOffs>656537152</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -55102,7 +54621,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656622272</BitOffs>
+            <BitOffs>656536576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_MR1L4</Name>
@@ -55143,7 +54662,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656622656</BitOffs>
+            <BitOffs>656536960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_MR2L3</Name>
@@ -55184,7 +54703,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656623040</BitOffs>
+            <BitOffs>656537344</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -55197,20 +54716,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Comment> M1 Serial Comm Function Block</Comment>
             <BitSize>10432</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>652794912</BitOffs>
+            <BitOffs>652709216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_MR1L4</Name>
             <Comment> M1 Serial Comm Function Block</Comment>
             <BitSize>10432</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>652805344</BitOffs>
+            <BitOffs>652719648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_MR2L3</Name>
             <BitSize>10432</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>652815776</BitOffs>
+            <BitOffs>652730080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_MR1L3</Name>
@@ -55222,7 +54741,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517696</BitOffs>
+            <BitOffs>654432000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_MR1L3</Name>
@@ -55233,7 +54752,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654520208</BitOffs>
+            <BitOffs>654434512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_MR1L4</Name>
@@ -55244,7 +54763,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654522720</BitOffs>
+            <BitOffs>654437024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_MR1L4</Name>
@@ -55255,7 +54774,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654525232</BitOffs>
+            <BitOffs>654439536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_MR2L3</Name>
@@ -55266,7 +54785,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654527744</BitOffs>
+            <BitOffs>654442048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_MR2L3</Name>
@@ -55277,7 +54796,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654530256</BitOffs>
+            <BitOffs>654444560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -55291,7 +54810,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656625504</BitOffs>
+            <BitOffs>656539808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -55305,7 +54824,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656627552</BitOffs>
+            <BitOffs>656541856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -55319,7 +54838,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656630656</BitOffs>
+            <BitOffs>656544960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -55340,7 +54859,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656630816</BitOffs>
+            <BitOffs>656545120</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -55788,19 +55307,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
 Beckhoff</Comment>
             <BitSize>109632</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>633717024</BitOffs>
+            <BitOffs>633633600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_MR2L3</Name>
             <BitSize>109632</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>633826944</BitOffs>
+            <BitOffs>633743520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_MR1L4</Name>
             <BitSize>109632</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>633936864</BitOffs>
+            <BitOffs>633853440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3.MR1L3_Pitch</Name>
@@ -55834,7 +55353,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654532928</BitOffs>
+            <BitOffs>654447232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4.MR1L4_Pitch</Name>
@@ -55868,7 +55387,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654535680</BitOffs>
+            <BitOffs>654449984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3.MR2L3_Pitch</Name>
@@ -55902,7 +55421,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538688</BitOffs>
+            <BitOffs>654452992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -55916,7 +55435,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656630688</BitOffs>
+            <BitOffs>656544992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -55930,7 +55449,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656630720</BitOffs>
+            <BitOffs>656545024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -55951,7 +55470,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656631520</BitOffs>
+            <BitOffs>656545824</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -55970,7 +55489,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>633680768</BitOffs>
+            <BitOffs>633597568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -55982,7 +55501,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634062208</BitOffs>
+            <BitOffs>633978816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -56005,7 +55524,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634070208</BitOffs>
+            <BitOffs>633986816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -56028,7 +55547,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634070216</BitOffs>
+            <BitOffs>633986824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -56051,7 +55570,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634070224</BitOffs>
+            <BitOffs>633986832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -56074,7 +55593,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634070240</BitOffs>
+            <BitOffs>633986848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -56087,7 +55606,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634070272</BitOffs>
+            <BitOffs>633986880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -56100,7 +55619,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634070336</BitOffs>
+            <BitOffs>633986944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -56113,7 +55632,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634070352</BitOffs>
+            <BitOffs>633986960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -56125,7 +55644,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634084864</BitOffs>
+            <BitOffs>634001472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -56137,7 +55656,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634382848</BitOffs>
+            <BitOffs>634299456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -56160,7 +55679,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634390848</BitOffs>
+            <BitOffs>634307456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -56183,7 +55702,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634390856</BitOffs>
+            <BitOffs>634307464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -56206,7 +55725,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634390864</BitOffs>
+            <BitOffs>634307472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -56229,7 +55748,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634390880</BitOffs>
+            <BitOffs>634307488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -56242,7 +55761,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634390912</BitOffs>
+            <BitOffs>634307520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -56255,7 +55774,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634390976</BitOffs>
+            <BitOffs>634307584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -56268,7 +55787,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634390992</BitOffs>
+            <BitOffs>634307600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -56280,7 +55799,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634405504</BitOffs>
+            <BitOffs>634322112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -56292,7 +55811,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634703488</BitOffs>
+            <BitOffs>634620096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -56315,7 +55834,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634711488</BitOffs>
+            <BitOffs>634628096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -56338,7 +55857,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634711496</BitOffs>
+            <BitOffs>634628104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -56361,7 +55880,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634711504</BitOffs>
+            <BitOffs>634628112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -56384,7 +55903,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634711520</BitOffs>
+            <BitOffs>634628128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -56397,7 +55916,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634711552</BitOffs>
+            <BitOffs>634628160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -56410,7 +55929,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634711616</BitOffs>
+            <BitOffs>634628224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -56423,7 +55942,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634711632</BitOffs>
+            <BitOffs>634628240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -56435,7 +55954,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634726144</BitOffs>
+            <BitOffs>634642752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -56447,7 +55966,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635024128</BitOffs>
+            <BitOffs>634940736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -56470,7 +55989,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635032128</BitOffs>
+            <BitOffs>634948736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -56493,7 +56012,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635032136</BitOffs>
+            <BitOffs>634948744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -56516,7 +56035,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635032144</BitOffs>
+            <BitOffs>634948752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -56539,7 +56058,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635032160</BitOffs>
+            <BitOffs>634948768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -56552,7 +56071,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635032192</BitOffs>
+            <BitOffs>634948800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -56565,7 +56084,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635032256</BitOffs>
+            <BitOffs>634948864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -56578,7 +56097,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635032272</BitOffs>
+            <BitOffs>634948880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -56590,7 +56109,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635046784</BitOffs>
+            <BitOffs>634963392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -56602,7 +56121,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635344768</BitOffs>
+            <BitOffs>635261376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -56625,7 +56144,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635352768</BitOffs>
+            <BitOffs>635269376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -56648,7 +56167,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635352776</BitOffs>
+            <BitOffs>635269384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -56671,7 +56190,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635352784</BitOffs>
+            <BitOffs>635269392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -56694,7 +56213,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635352800</BitOffs>
+            <BitOffs>635269408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -56707,7 +56226,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635352832</BitOffs>
+            <BitOffs>635269440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -56720,7 +56239,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635352896</BitOffs>
+            <BitOffs>635269504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -56733,7 +56252,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635352912</BitOffs>
+            <BitOffs>635269520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -56745,7 +56264,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635367424</BitOffs>
+            <BitOffs>635284032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -56757,7 +56276,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635665408</BitOffs>
+            <BitOffs>635582016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -56780,7 +56299,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635673408</BitOffs>
+            <BitOffs>635590016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -56803,7 +56322,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635673416</BitOffs>
+            <BitOffs>635590024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -56826,7 +56345,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635673424</BitOffs>
+            <BitOffs>635590032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -56849,7 +56368,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635673440</BitOffs>
+            <BitOffs>635590048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -56862,7 +56381,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635673472</BitOffs>
+            <BitOffs>635590080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -56875,7 +56394,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635673536</BitOffs>
+            <BitOffs>635590144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -56888,7 +56407,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635673552</BitOffs>
+            <BitOffs>635590160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -56900,7 +56419,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635688064</BitOffs>
+            <BitOffs>635604672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.bSTOEnable1</Name>
@@ -56913,7 +56432,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635985888</BitOffs>
+            <BitOffs>635902496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.bSTOEnable2</Name>
@@ -56925,7 +56444,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635985896</BitOffs>
+            <BitOffs>635902504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stYupEnc</Name>
@@ -56938,7 +56457,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635985920</BitOffs>
+            <BitOffs>635902528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stYdwnEnc</Name>
@@ -56950,7 +56469,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986048</BitOffs>
+            <BitOffs>635902656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stXupEnc</Name>
@@ -56962,7 +56481,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986176</BitOffs>
+            <BitOffs>635902784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.stXdwnEnc</Name>
@@ -56974,7 +56493,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986304</BitOffs>
+            <BitOffs>635902912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -56987,7 +56506,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635986880</BitOffs>
+            <BitOffs>635903488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -57000,7 +56519,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635987008</BitOffs>
+            <BitOffs>635903616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -57013,7 +56532,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635996352</BitOffs>
+            <BitOffs>635912960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -57026,7 +56545,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635996480</BitOffs>
+            <BitOffs>635913088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
@@ -57039,7 +56558,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636006624</BitOffs>
+            <BitOffs>635923232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.bSTOEnable2</Name>
@@ -57051,7 +56570,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636006632</BitOffs>
+            <BitOffs>635923240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stYupEnc</Name>
@@ -57064,7 +56583,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636006656</BitOffs>
+            <BitOffs>635923264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
@@ -57076,7 +56595,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636006784</BitOffs>
+            <BitOffs>635923392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stXupEnc</Name>
@@ -57088,7 +56607,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636006912</BitOffs>
+            <BitOffs>635923520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
@@ -57100,7 +56619,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636007040</BitOffs>
+            <BitOffs>635923648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -57113,7 +56632,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636007616</BitOffs>
+            <BitOffs>635924224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -57126,7 +56645,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636007744</BitOffs>
+            <BitOffs>635924352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -57139,7 +56658,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636017088</BitOffs>
+            <BitOffs>635933696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -57152,7 +56671,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636017216</BitOffs>
+            <BitOffs>635933824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
@@ -57164,7 +56683,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636027456</BitOffs>
+            <BitOffs>635944064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
@@ -57187,7 +56706,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636035456</BitOffs>
+            <BitOffs>635952064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
@@ -57210,7 +56729,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636035464</BitOffs>
+            <BitOffs>635952072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bHome</Name>
@@ -57233,7 +56752,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636035472</BitOffs>
+            <BitOffs>635952080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bHardwareEnable</Name>
@@ -57256,7 +56775,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636035488</BitOffs>
+            <BitOffs>635952096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
@@ -57269,7 +56788,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636035520</BitOffs>
+            <BitOffs>635952128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
@@ -57282,7 +56801,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636035584</BitOffs>
+            <BitOffs>635952192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.nRawEncoderINT</Name>
@@ -57295,7 +56814,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636035600</BitOffs>
+            <BitOffs>635952208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
@@ -57307,7 +56826,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636048704</BitOffs>
+            <BitOffs>635965312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
@@ -57330,7 +56849,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636056704</BitOffs>
+            <BitOffs>635973312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
@@ -57353,7 +56872,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636056712</BitOffs>
+            <BitOffs>635973320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bHome</Name>
@@ -57376,7 +56895,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636056720</BitOffs>
+            <BitOffs>635973328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bHardwareEnable</Name>
@@ -57399,7 +56918,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636056736</BitOffs>
+            <BitOffs>635973344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
@@ -57412,7 +56931,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636056768</BitOffs>
+            <BitOffs>635973376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
@@ -57425,7 +56944,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636056832</BitOffs>
+            <BitOffs>635973440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.nRawEncoderINT</Name>
@@ -57438,7 +56957,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636056848</BitOffs>
+            <BitOffs>635973456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -57450,7 +56969,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638068352</BitOffs>
+            <BitOffs>637984192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -57462,7 +56981,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638377664</BitOffs>
+            <BitOffs>638293504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -57485,7 +57004,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638385664</BitOffs>
+            <BitOffs>638301504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -57508,7 +57027,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638385672</BitOffs>
+            <BitOffs>638301512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -57531,7 +57050,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638385680</BitOffs>
+            <BitOffs>638301520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -57554,7 +57073,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638385696</BitOffs>
+            <BitOffs>638301536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -57567,7 +57086,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638385728</BitOffs>
+            <BitOffs>638301568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -57580,7 +57099,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638385792</BitOffs>
+            <BitOffs>638301632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -57593,7 +57112,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638385808</BitOffs>
+            <BitOffs>638301648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m7.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -57605,7 +57124,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638400320</BitOffs>
+            <BitOffs>638316160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -57617,7 +57136,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638698304</BitOffs>
+            <BitOffs>638614144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -57640,7 +57159,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638706304</BitOffs>
+            <BitOffs>638622144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -57663,7 +57182,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638706312</BitOffs>
+            <BitOffs>638622152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -57686,7 +57205,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638706320</BitOffs>
+            <BitOffs>638622160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -57709,7 +57228,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638706336</BitOffs>
+            <BitOffs>638622176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -57722,7 +57241,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638706368</BitOffs>
+            <BitOffs>638622208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -57735,7 +57254,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638706432</BitOffs>
+            <BitOffs>638622272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -57748,7 +57267,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638706448</BitOffs>
+            <BitOffs>638622288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m8.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -57760,7 +57279,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638720960</BitOffs>
+            <BitOffs>638636800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -57772,7 +57291,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639018944</BitOffs>
+            <BitOffs>638934784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -57795,7 +57314,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639026944</BitOffs>
+            <BitOffs>638942784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -57818,7 +57337,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639026952</BitOffs>
+            <BitOffs>638942792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -57841,7 +57360,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639026960</BitOffs>
+            <BitOffs>638942800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -57864,7 +57383,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639026976</BitOffs>
+            <BitOffs>638942816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -57877,7 +57396,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639027008</BitOffs>
+            <BitOffs>638942848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -57890,7 +57409,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639027072</BitOffs>
+            <BitOffs>638942912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -57903,7 +57422,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639027088</BitOffs>
+            <BitOffs>638942928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m9.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -57915,7 +57434,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639041600</BitOffs>
+            <BitOffs>638957440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -57927,7 +57446,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639339584</BitOffs>
+            <BitOffs>639255424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -57950,7 +57469,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639347584</BitOffs>
+            <BitOffs>639263424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -57973,7 +57492,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639347592</BitOffs>
+            <BitOffs>639263432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -57996,7 +57515,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639347600</BitOffs>
+            <BitOffs>639263440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -58019,7 +57538,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639347616</BitOffs>
+            <BitOffs>639263456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -58032,7 +57551,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639347648</BitOffs>
+            <BitOffs>639263488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -58045,7 +57564,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639347712</BitOffs>
+            <BitOffs>639263552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -58058,7 +57577,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639347728</BitOffs>
+            <BitOffs>639263568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m10.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -58070,7 +57589,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639362240</BitOffs>
+            <BitOffs>639278080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -58082,7 +57601,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639660224</BitOffs>
+            <BitOffs>639576064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -58105,7 +57624,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639668224</BitOffs>
+            <BitOffs>639584064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -58128,7 +57647,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639668232</BitOffs>
+            <BitOffs>639584072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -58151,7 +57670,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639668240</BitOffs>
+            <BitOffs>639584080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -58174,7 +57693,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639668256</BitOffs>
+            <BitOffs>639584096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -58187,7 +57706,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639668288</BitOffs>
+            <BitOffs>639584128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -58200,7 +57719,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639668352</BitOffs>
+            <BitOffs>639584192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -58213,7 +57732,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639668368</BitOffs>
+            <BitOffs>639584208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m11.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -58225,7 +57744,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639682880</BitOffs>
+            <BitOffs>639598720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -58237,7 +57756,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639980864</BitOffs>
+            <BitOffs>639896704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -58260,7 +57779,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639988864</BitOffs>
+            <BitOffs>639904704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -58283,7 +57802,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639988872</BitOffs>
+            <BitOffs>639904712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -58306,7 +57825,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639988880</BitOffs>
+            <BitOffs>639904720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -58329,7 +57848,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639988896</BitOffs>
+            <BitOffs>639904736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -58342,7 +57861,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639988928</BitOffs>
+            <BitOffs>639904768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -58355,7 +57874,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639988992</BitOffs>
+            <BitOffs>639904832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -58368,7 +57887,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639989008</BitOffs>
+            <BitOffs>639904848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -58380,7 +57899,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640003520</BitOffs>
+            <BitOffs>639919360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.bSTOEnable1</Name>
@@ -58393,7 +57912,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640301344</BitOffs>
+            <BitOffs>640217184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.bSTOEnable2</Name>
@@ -58405,7 +57924,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640301352</BitOffs>
+            <BitOffs>640217192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stYupEnc</Name>
@@ -58418,7 +57937,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640301376</BitOffs>
+            <BitOffs>640217216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stYdwnEnc</Name>
@@ -58430,7 +57949,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640301504</BitOffs>
+            <BitOffs>640217344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stXupEnc</Name>
@@ -58442,7 +57961,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640301632</BitOffs>
+            <BitOffs>640217472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.stXdwnEnc</Name>
@@ -58454,7 +57973,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640301760</BitOffs>
+            <BitOffs>640217600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -58467,7 +57986,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640302336</BitOffs>
+            <BitOffs>640218176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -58480,7 +57999,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640302464</BitOffs>
+            <BitOffs>640218304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -58493,7 +58012,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640311808</BitOffs>
+            <BitOffs>640227648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -58506,7 +58025,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640311936</BitOffs>
+            <BitOffs>640227776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
@@ -58519,7 +58038,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640322080</BitOffs>
+            <BitOffs>640237920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.bSTOEnable2</Name>
@@ -58531,7 +58050,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640322088</BitOffs>
+            <BitOffs>640237928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stYupEnc</Name>
@@ -58544,7 +58063,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640322112</BitOffs>
+            <BitOffs>640237952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
@@ -58556,7 +58075,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640322240</BitOffs>
+            <BitOffs>640238080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stXupEnc</Name>
@@ -58568,7 +58087,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640322368</BitOffs>
+            <BitOffs>640238208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
@@ -58580,7 +58099,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640322496</BitOffs>
+            <BitOffs>640238336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -58593,7 +58112,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640323072</BitOffs>
+            <BitOffs>640238912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -58606,7 +58125,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640323200</BitOffs>
+            <BitOffs>640239040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -58619,7 +58138,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640332544</BitOffs>
+            <BitOffs>640248384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -58632,7 +58151,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640332672</BitOffs>
+            <BitOffs>640248512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
@@ -58644,7 +58163,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640342912</BitOffs>
+            <BitOffs>640258752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
@@ -58667,7 +58186,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640350912</BitOffs>
+            <BitOffs>640266752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
@@ -58690,7 +58209,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640350920</BitOffs>
+            <BitOffs>640266760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bHome</Name>
@@ -58713,7 +58232,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640350928</BitOffs>
+            <BitOffs>640266768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bHardwareEnable</Name>
@@ -58736,7 +58255,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640350944</BitOffs>
+            <BitOffs>640266784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
@@ -58749,7 +58268,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640350976</BitOffs>
+            <BitOffs>640266816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
@@ -58762,7 +58281,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640351040</BitOffs>
+            <BitOffs>640266880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.nRawEncoderINT</Name>
@@ -58775,7 +58294,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640351056</BitOffs>
+            <BitOffs>640266896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
@@ -58787,7 +58306,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640364160</BitOffs>
+            <BitOffs>640280000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
@@ -58810,7 +58329,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640372160</BitOffs>
+            <BitOffs>640288000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
@@ -58833,7 +58352,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640372168</BitOffs>
+            <BitOffs>640288008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bHome</Name>
@@ -58856,7 +58375,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640372176</BitOffs>
+            <BitOffs>640288016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bHardwareEnable</Name>
@@ -58879,7 +58398,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640372192</BitOffs>
+            <BitOffs>640288032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
@@ -58892,7 +58411,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640372224</BitOffs>
+            <BitOffs>640288064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
@@ -58905,7 +58424,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640372288</BitOffs>
+            <BitOffs>640288128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.nRawEncoderINT</Name>
@@ -58918,7 +58437,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640372304</BitOffs>
+            <BitOffs>640288144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -58930,7 +58449,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642383808</BitOffs>
+            <BitOffs>642298880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -58942,7 +58461,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642693120</BitOffs>
+            <BitOffs>642608192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -58965,7 +58484,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642701120</BitOffs>
+            <BitOffs>642616192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -58988,7 +58507,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642701128</BitOffs>
+            <BitOffs>642616200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -59011,7 +58530,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642701136</BitOffs>
+            <BitOffs>642616208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -59034,7 +58553,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642701152</BitOffs>
+            <BitOffs>642616224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -59047,7 +58566,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642701184</BitOffs>
+            <BitOffs>642616256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -59060,7 +58579,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642701248</BitOffs>
+            <BitOffs>642616320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -59073,7 +58592,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642701264</BitOffs>
+            <BitOffs>642616336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59085,7 +58604,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642715776</BitOffs>
+            <BitOffs>642630848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -59097,7 +58616,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643013760</BitOffs>
+            <BitOffs>642928832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -59120,7 +58639,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643021760</BitOffs>
+            <BitOffs>642936832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -59143,7 +58662,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643021768</BitOffs>
+            <BitOffs>642936840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -59166,7 +58685,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643021776</BitOffs>
+            <BitOffs>642936848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -59189,7 +58708,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643021792</BitOffs>
+            <BitOffs>642936864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -59202,7 +58721,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643021824</BitOffs>
+            <BitOffs>642936896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -59215,7 +58734,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643021888</BitOffs>
+            <BitOffs>642936960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -59228,7 +58747,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643021904</BitOffs>
+            <BitOffs>642936976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59240,7 +58759,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643036416</BitOffs>
+            <BitOffs>642951488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -59252,7 +58771,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643334400</BitOffs>
+            <BitOffs>643249472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -59275,7 +58794,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643342400</BitOffs>
+            <BitOffs>643257472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -59298,7 +58817,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643342408</BitOffs>
+            <BitOffs>643257480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -59321,7 +58840,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643342416</BitOffs>
+            <BitOffs>643257488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -59344,7 +58863,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643342432</BitOffs>
+            <BitOffs>643257504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -59357,7 +58876,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643342464</BitOffs>
+            <BitOffs>643257536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -59370,7 +58889,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643342528</BitOffs>
+            <BitOffs>643257600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -59383,7 +58902,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643342544</BitOffs>
+            <BitOffs>643257616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59395,7 +58914,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643357056</BitOffs>
+            <BitOffs>643272128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -59407,7 +58926,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643655040</BitOffs>
+            <BitOffs>643570112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -59430,7 +58949,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643663040</BitOffs>
+            <BitOffs>643578112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -59453,7 +58972,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643663048</BitOffs>
+            <BitOffs>643578120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -59476,7 +58995,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643663056</BitOffs>
+            <BitOffs>643578128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -59499,7 +59018,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643663072</BitOffs>
+            <BitOffs>643578144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -59512,7 +59031,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643663104</BitOffs>
+            <BitOffs>643578176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -59525,7 +59044,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643663168</BitOffs>
+            <BitOffs>643578240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -59538,7 +59057,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643663184</BitOffs>
+            <BitOffs>643578256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59550,7 +59069,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643677696</BitOffs>
+            <BitOffs>643592768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -59562,7 +59081,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643975680</BitOffs>
+            <BitOffs>643890752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -59585,7 +59104,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643983680</BitOffs>
+            <BitOffs>643898752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -59608,7 +59127,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643983688</BitOffs>
+            <BitOffs>643898760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -59631,7 +59150,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643983696</BitOffs>
+            <BitOffs>643898768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -59654,7 +59173,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643983712</BitOffs>
+            <BitOffs>643898784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -59667,7 +59186,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643983744</BitOffs>
+            <BitOffs>643898816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -59680,7 +59199,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643983808</BitOffs>
+            <BitOffs>643898880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -59693,7 +59212,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643983824</BitOffs>
+            <BitOffs>643898896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59705,7 +59224,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643998336</BitOffs>
+            <BitOffs>643913408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -59717,7 +59236,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644296320</BitOffs>
+            <BitOffs>644211392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -59740,7 +59259,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644304320</BitOffs>
+            <BitOffs>644219392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -59763,7 +59282,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644304328</BitOffs>
+            <BitOffs>644219400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -59786,7 +59305,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644304336</BitOffs>
+            <BitOffs>644219408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -59809,7 +59328,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644304352</BitOffs>
+            <BitOffs>644219424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -59822,7 +59341,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644304384</BitOffs>
+            <BitOffs>644219456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -59835,7 +59354,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644304448</BitOffs>
+            <BitOffs>644219520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -59848,7 +59367,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644304464</BitOffs>
+            <BitOffs>644219536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59860,7 +59379,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644318976</BitOffs>
+            <BitOffs>644234048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.bSTOEnable1</Name>
@@ -59873,7 +59392,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644616800</BitOffs>
+            <BitOffs>644531872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.bSTOEnable2</Name>
@@ -59885,7 +59404,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644616808</BitOffs>
+            <BitOffs>644531880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stYupEnc</Name>
@@ -59898,7 +59417,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644616832</BitOffs>
+            <BitOffs>644531904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stYdwnEnc</Name>
@@ -59910,7 +59429,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644616960</BitOffs>
+            <BitOffs>644532032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stXupEnc</Name>
@@ -59922,7 +59441,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644617088</BitOffs>
+            <BitOffs>644532160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.stXdwnEnc</Name>
@@ -59934,7 +59453,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644617216</BitOffs>
+            <BitOffs>644532288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -59947,7 +59466,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644617792</BitOffs>
+            <BitOffs>644532864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -59960,7 +59479,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644617920</BitOffs>
+            <BitOffs>644532992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -59973,7 +59492,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644627264</BitOffs>
+            <BitOffs>644542336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -59986,7 +59505,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644627392</BitOffs>
+            <BitOffs>644542464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.bSTOEnable1</Name>
@@ -59999,7 +59518,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644637536</BitOffs>
+            <BitOffs>644552608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.bSTOEnable2</Name>
@@ -60011,7 +59530,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644637544</BitOffs>
+            <BitOffs>644552616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stYupEnc</Name>
@@ -60024,7 +59543,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644637568</BitOffs>
+            <BitOffs>644552640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stYdwnEnc</Name>
@@ -60036,7 +59555,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644637696</BitOffs>
+            <BitOffs>644552768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stXupEnc</Name>
@@ -60048,7 +59567,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644637824</BitOffs>
+            <BitOffs>644552896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.stXdwnEnc</Name>
@@ -60060,7 +59579,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644637952</BitOffs>
+            <BitOffs>644553024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -60073,7 +59592,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644638528</BitOffs>
+            <BitOffs>644553600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -60086,7 +59605,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644638656</BitOffs>
+            <BitOffs>644553728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -60099,7 +59618,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644648000</BitOffs>
+            <BitOffs>644563072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.homs.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -60112,7 +59631,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644648128</BitOffs>
+            <BitOffs>644563200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.Axis.NcToPlc</Name>
@@ -60124,7 +59643,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644658368</BitOffs>
+            <BitOffs>644573440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bLimitForwardEnable</Name>
@@ -60147,7 +59666,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644666368</BitOffs>
+            <BitOffs>644581440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bLimitBackwardEnable</Name>
@@ -60170,7 +59689,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644666376</BitOffs>
+            <BitOffs>644581448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bHome</Name>
@@ -60193,7 +59712,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644666384</BitOffs>
+            <BitOffs>644581456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bHardwareEnable</Name>
@@ -60216,7 +59735,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644666400</BitOffs>
+            <BitOffs>644581472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderULINT</Name>
@@ -60229,7 +59748,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644666432</BitOffs>
+            <BitOffs>644581504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderUINT</Name>
@@ -60242,7 +59761,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644666496</BitOffs>
+            <BitOffs>644581568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.nRawEncoderINT</Name>
@@ -60255,7 +59774,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644666512</BitOffs>
+            <BitOffs>644581584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.Axis.NcToPlc</Name>
@@ -60267,7 +59786,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644679616</BitOffs>
+            <BitOffs>644594688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bLimitForwardEnable</Name>
@@ -60290,7 +59809,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644687616</BitOffs>
+            <BitOffs>644602688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bLimitBackwardEnable</Name>
@@ -60313,7 +59832,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644687624</BitOffs>
+            <BitOffs>644602696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bHome</Name>
@@ -60336,7 +59855,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644687632</BitOffs>
+            <BitOffs>644602704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bHardwareEnable</Name>
@@ -60359,7 +59878,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644687648</BitOffs>
+            <BitOffs>644602720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderULINT</Name>
@@ -60372,7 +59891,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644687680</BitOffs>
+            <BitOffs>644602752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderUINT</Name>
@@ -60385,7 +59904,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644687744</BitOffs>
+            <BitOffs>644602816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.nRawEncoderINT</Name>
@@ -60398,7 +59917,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644687760</BitOffs>
+            <BitOffs>644602832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60410,7 +59929,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646699264</BitOffs>
+            <BitOffs>646613568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gAmsNetIDEcatMaster1</Name>
@@ -60425,7 +59944,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517504</BitOffs>
+            <BitOffs>654431808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3.MR1L3_Pitch.diEncCnt</Name>
@@ -60438,7 +59957,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654535360</BitOffs>
+            <BitOffs>654449664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4.MR1L4_Pitch.diEncCnt</Name>
@@ -60451,7 +59970,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654538112</BitOffs>
+            <BitOffs>654452416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3.MR2L3_Pitch.diEncCnt</Name>
@@ -60464,7 +59983,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654541120</BitOffs>
+            <BitOffs>654455424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.i_stCurrentBP</Name>
@@ -60480,7 +59999,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656481824</BitOffs>
+            <BitOffs>656396128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.xTxPDO_toggle</Name>
@@ -60501,7 +60020,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656485344</BitOffs>
+            <BitOffs>656399648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.xTxPDO_state</Name>
@@ -60522,7 +60041,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656485345</BitOffs>
+            <BitOffs>656399649</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bError</Name>
@@ -60546,7 +60065,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656619976</BitOffs>
+            <BitOffs>656534280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bUnderrange</Name>
@@ -60558,7 +60077,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656619984</BitOffs>
+            <BitOffs>656534288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.bOverrange</Name>
@@ -60570,7 +60089,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656619992</BitOffs>
+            <BitOffs>656534296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_1.iRaw</Name>
@@ -60582,7 +60101,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620000</BitOffs>
+            <BitOffs>656534304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bError</Name>
@@ -60606,7 +60125,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620232</BitOffs>
+            <BitOffs>656534536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bUnderrange</Name>
@@ -60618,7 +60137,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620240</BitOffs>
+            <BitOffs>656534544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.bOverrange</Name>
@@ -60630,7 +60149,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620248</BitOffs>
+            <BitOffs>656534552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_2.iRaw</Name>
@@ -60642,7 +60161,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620256</BitOffs>
+            <BitOffs>656534560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bError</Name>
@@ -60666,7 +60185,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620488</BitOffs>
+            <BitOffs>656534792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bUnderrange</Name>
@@ -60678,7 +60197,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620496</BitOffs>
+            <BitOffs>656534800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.bOverrange</Name>
@@ -60690,7 +60209,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620504</BitOffs>
+            <BitOffs>656534808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_3.iRaw</Name>
@@ -60702,7 +60221,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620512</BitOffs>
+            <BitOffs>656534816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bError</Name>
@@ -60726,7 +60245,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620744</BitOffs>
+            <BitOffs>656535048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bUnderrange</Name>
@@ -60738,7 +60257,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620752</BitOffs>
+            <BitOffs>656535056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.bOverrange</Name>
@@ -60750,7 +60269,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620760</BitOffs>
+            <BitOffs>656535064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_1.iRaw</Name>
@@ -60762,7 +60281,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656620768</BitOffs>
+            <BitOffs>656535072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bError</Name>
@@ -60786,7 +60305,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621000</BitOffs>
+            <BitOffs>656535304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bUnderrange</Name>
@@ -60798,7 +60317,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621008</BitOffs>
+            <BitOffs>656535312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.bOverrange</Name>
@@ -60810,7 +60329,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621016</BitOffs>
+            <BitOffs>656535320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_2.iRaw</Name>
@@ -60822,7 +60341,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621024</BitOffs>
+            <BitOffs>656535328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bError</Name>
@@ -60846,7 +60365,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621256</BitOffs>
+            <BitOffs>656535560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bUnderrange</Name>
@@ -60858,7 +60377,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621264</BitOffs>
+            <BitOffs>656535568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.bOverrange</Name>
@@ -60870,7 +60389,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621272</BitOffs>
+            <BitOffs>656535576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_3.iRaw</Name>
@@ -60882,7 +60401,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621280</BitOffs>
+            <BitOffs>656535584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bError</Name>
@@ -60906,7 +60425,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621512</BitOffs>
+            <BitOffs>656535816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bUnderrange</Name>
@@ -60918,7 +60437,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621520</BitOffs>
+            <BitOffs>656535824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.bOverrange</Name>
@@ -60930,7 +60449,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621528</BitOffs>
+            <BitOffs>656535832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_1.iRaw</Name>
@@ -60942,7 +60461,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621536</BitOffs>
+            <BitOffs>656535840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bError</Name>
@@ -60966,7 +60485,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621768</BitOffs>
+            <BitOffs>656536072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bUnderrange</Name>
@@ -60978,7 +60497,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621776</BitOffs>
+            <BitOffs>656536080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.bOverrange</Name>
@@ -60990,7 +60509,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621784</BitOffs>
+            <BitOffs>656536088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_2.iRaw</Name>
@@ -61002,7 +60521,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656621792</BitOffs>
+            <BitOffs>656536096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bError</Name>
@@ -61026,7 +60545,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656622024</BitOffs>
+            <BitOffs>656536328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bUnderrange</Name>
@@ -61038,7 +60557,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656622032</BitOffs>
+            <BitOffs>656536336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.bOverrange</Name>
@@ -61050,7 +60569,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656622040</BitOffs>
+            <BitOffs>656536344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_3.iRaw</Name>
@@ -61062,7 +60581,7 @@ Beckhoff</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656622048</BitOffs>
+            <BitOffs>656536352</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -61080,7 +60599,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634061184</BitOffs>
+            <BitOffs>633977792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -61103,7 +60622,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634070232</BitOffs>
+            <BitOffs>633986840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61115,7 +60634,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634083840</BitOffs>
+            <BitOffs>634000448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -61127,7 +60646,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634381824</BitOffs>
+            <BitOffs>634298432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -61150,7 +60669,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634390872</BitOffs>
+            <BitOffs>634307480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61162,7 +60681,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634404480</BitOffs>
+            <BitOffs>634321088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -61174,7 +60693,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634702464</BitOffs>
+            <BitOffs>634619072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -61197,7 +60716,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634711512</BitOffs>
+            <BitOffs>634628120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61209,7 +60728,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634725120</BitOffs>
+            <BitOffs>634641728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -61221,7 +60740,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635023104</BitOffs>
+            <BitOffs>634939712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -61244,7 +60763,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635032152</BitOffs>
+            <BitOffs>634948760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61256,7 +60775,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635045760</BitOffs>
+            <BitOffs>634962368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -61268,7 +60787,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635343744</BitOffs>
+            <BitOffs>635260352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -61291,7 +60810,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635352792</BitOffs>
+            <BitOffs>635269400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61303,7 +60822,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635366400</BitOffs>
+            <BitOffs>635283008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -61315,7 +60834,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635664384</BitOffs>
+            <BitOffs>635580992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -61338,7 +60857,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635673432</BitOffs>
+            <BitOffs>635590040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61350,7 +60869,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635687040</BitOffs>
+            <BitOffs>635603648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.Axis.PlcToNc</Name>
@@ -61362,7 +60881,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636026432</BitOffs>
+            <BitOffs>635943040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamY.bBrakeRelease</Name>
@@ -61385,7 +60904,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636035480</BitOffs>
+            <BitOffs>635952088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.Axis.PlcToNc</Name>
@@ -61397,7 +60916,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636047680</BitOffs>
+            <BitOffs>635964288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats.fbUpStreamX.bBrakeRelease</Name>
@@ -61420,7 +60939,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636056728</BitOffs>
+            <BitOffs>635973336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61432,7 +60951,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638067328</BitOffs>
+            <BitOffs>637983168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -61444,7 +60963,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638376640</BitOffs>
+            <BitOffs>638292480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -61467,7 +60986,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638385688</BitOffs>
+            <BitOffs>638301528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m7.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61479,7 +60998,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638399296</BitOffs>
+            <BitOffs>638315136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -61491,7 +61010,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638697280</BitOffs>
+            <BitOffs>638613120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -61514,7 +61033,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638706328</BitOffs>
+            <BitOffs>638622168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m8.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61526,7 +61045,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638719936</BitOffs>
+            <BitOffs>638635776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -61538,7 +61057,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639017920</BitOffs>
+            <BitOffs>638933760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -61561,7 +61080,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639026968</BitOffs>
+            <BitOffs>638942808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m9.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61573,7 +61092,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639040576</BitOffs>
+            <BitOffs>638956416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -61585,7 +61104,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639338560</BitOffs>
+            <BitOffs>639254400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -61608,7 +61127,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639347608</BitOffs>
+            <BitOffs>639263448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m10.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61620,7 +61139,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639361216</BitOffs>
+            <BitOffs>639277056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -61632,7 +61151,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639659200</BitOffs>
+            <BitOffs>639575040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -61655,7 +61174,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639668248</BitOffs>
+            <BitOffs>639584088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m11.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61667,7 +61186,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639681856</BitOffs>
+            <BitOffs>639597696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -61679,7 +61198,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639979840</BitOffs>
+            <BitOffs>639895680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -61702,7 +61221,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639988888</BitOffs>
+            <BitOffs>639904728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61714,7 +61233,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640002496</BitOffs>
+            <BitOffs>639918336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.Axis.PlcToNc</Name>
@@ -61726,7 +61245,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640341888</BitOffs>
+            <BitOffs>640257728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamY.bBrakeRelease</Name>
@@ -61749,7 +61268,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640350936</BitOffs>
+            <BitOffs>640266776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.Axis.PlcToNc</Name>
@@ -61761,7 +61280,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640363136</BitOffs>
+            <BitOffs>640278976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats.fbUpStreamX.bBrakeRelease</Name>
@@ -61784,7 +61303,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640372184</BitOffs>
+            <BitOffs>640288024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61796,7 +61315,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642382784</BitOffs>
+            <BitOffs>642297856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -61808,7 +61327,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642692096</BitOffs>
+            <BitOffs>642607168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -61831,7 +61350,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642701144</BitOffs>
+            <BitOffs>642616216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61843,7 +61362,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642714752</BitOffs>
+            <BitOffs>642629824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -61855,7 +61374,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643012736</BitOffs>
+            <BitOffs>642927808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -61878,7 +61397,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643021784</BitOffs>
+            <BitOffs>642936856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61890,7 +61409,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643035392</BitOffs>
+            <BitOffs>642950464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -61902,7 +61421,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643333376</BitOffs>
+            <BitOffs>643248448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -61925,7 +61444,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643342424</BitOffs>
+            <BitOffs>643257496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61937,7 +61456,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643356032</BitOffs>
+            <BitOffs>643271104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -61949,7 +61468,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643654016</BitOffs>
+            <BitOffs>643569088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -61972,7 +61491,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643663064</BitOffs>
+            <BitOffs>643578136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -61984,7 +61503,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643676672</BitOffs>
+            <BitOffs>643591744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -61996,7 +61515,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643974656</BitOffs>
+            <BitOffs>643889728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -62019,7 +61538,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643983704</BitOffs>
+            <BitOffs>643898776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -62031,7 +61550,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643997312</BitOffs>
+            <BitOffs>643912384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -62043,7 +61562,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644295296</BitOffs>
+            <BitOffs>644210368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -62066,7 +61585,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644304344</BitOffs>
+            <BitOffs>644219416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -62078,7 +61597,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644317952</BitOffs>
+            <BitOffs>644233024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.Axis.PlcToNc</Name>
@@ -62090,7 +61609,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644657344</BitOffs>
+            <BitOffs>644572416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamY.bBrakeRelease</Name>
@@ -62113,7 +61632,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644666392</BitOffs>
+            <BitOffs>644581464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.Axis.PlcToNc</Name>
@@ -62125,7 +61644,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644678592</BitOffs>
+            <BitOffs>644593664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats.fbUpStreamX.bBrakeRelease</Name>
@@ -62148,7 +61667,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644687640</BitOffs>
+            <BitOffs>644602712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -62160,7 +61679,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646698240</BitOffs>
+            <BitOffs>646612544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.bXRT_M2_OUT</Name>
@@ -62185,7 +61704,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517552</BitOffs>
+            <BitOffs>654431856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.bXRT_M2_IN</Name>
@@ -62209,7 +61728,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517560</BitOffs>
+            <BitOffs>654431864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput1.q_xFastFaultOut</Name>
@@ -62229,7 +61748,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654541448</BitOffs>
+            <BitOffs>654455752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2.q_xFastFaultOut</Name>
@@ -62249,7 +61768,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655036744</BitOffs>
+            <BitOffs>654951048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO.q_stRequestedBP</Name>
@@ -62265,7 +61784,7 @@ Beckhoff</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656483584</BitOffs>
+            <BitOffs>656397888</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -67610,23 +67129,9 @@ Beckhoff</Comment>
             <BitOffs>625200128</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Logger.bTrickleTripped</Name>
-            <Comment> Global trickle trip flag</Comment>
+            <Name>Main.bMR1L3PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
-        io: i
-        field: DESC Tripped by overall log count
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
             <BitOffs>625200136</BitOffs>
           </Symbol>
           <Symbol>
@@ -67743,15 +67248,12 @@ Beckhoff</Comment>
             <BitOffs>633569312</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GeneralConstants.MAX_STATES</Name>
-            <Comment> 16 including "Unknown" is the max for an EPICS MBBI/MBBO
- This is the max number of user-defined states (OUT, TARGET1, YAG...)
- You can make this smaller if you want to use less memory in your program in exchange for limiting your max state count
- You can make this larger if you want to use states-based FBs sized beyond the EPICS enum limit</Comment>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
             <Default>
-              <Value>15</Value>
+              <Value>16</Value>
             </Default>
             <Properties>
               <Property>
@@ -67789,286 +67291,6 @@ Beckhoff</Comment>
             <BitOffs>633572288</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>DefaultGlobals.stSys</Name>
-            <Comment>Included for you</Comment>
-            <BitSize>40</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.LCLS_General">ST_System</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575232</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR1L3PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>633575272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.iLogPort</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>54321</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:LogPort
-        io: io
-        field: DESC The log host UDP port
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>DefaultGlobals.fTimeStamp</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.cLogHost</Name>
-            <Comment>
-    Using the IP address directly avoids DNS configuration issues.
-    While we may want to address this in the future, for now the static IP
-    will suffice:
-
-    $ nslookup ctl-logsrv01
-    Name:   ctl-logsrv01.pcdsn
-    Address: 172.21.32.36
-    </Comment>
-            <BitSize>128</BitSize>
-            <BaseType>STRING(15)</BaseType>
-            <Default>
-              <String>172.21.32.36</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:LogHost
-        io: io
-        field: DESC The log host IP address
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.sIpTidbit</Name>
-            <BitSize>56</BitSize>
-            <BaseType>STRING(6)</BaseType>
-            <Default>
-              <String>172.21</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR1L3PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>633575544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nLocalTripThreshold</Name>
-            <Comment> Minimum time between log messages</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
-            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
-            <Comment> Maximum # of attenuators in the PMPS</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
-            <Comment> Default trickle trip, activated by global threshold</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTrickleTripTime</Name>
-            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTripResetPeriod</Name>
-            <Comment> Default time for CB auto-reset</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>600000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.sPlcHostname</Name>
-            <BitSize>648</BitSize>
-            <BaseType>STRING(80)</BaseType>
-            <Default>
-              <String>unknown</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633575712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR1L4PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>633576360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633576368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
-            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
-        TODO: Activate the "Replace constants" option in the
-        TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window.
-    </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>analysis</Name>
-                <Value>-33</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633576384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nGlobAccEvents</Name>
-            <Comment> Global log message count</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:LogMessageCount
-        io: i
-        field: DESC Total log messages on the last cycle
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633576416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.fbRootLogger</Name>
-            <Comment>Instantiated here to be used everywhere</Comment>
-            <BitSize>81984</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.LCLS_General">FB_LogMessage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633576448</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
             <Comment>Summarized request for the line, as recognized by the line arbiter PLC</Comment>
             <BitSize>1760</BitSize>
@@ -68086,7 +67308,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633658432</BitOffs>
+            <BitOffs>633575232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -68106,7 +67328,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633660192</BitOffs>
+            <BitOffs>633576992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -68131,7 +67353,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633661952</BitOffs>
+            <BitOffs>633578752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -68143,7 +67365,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633662976</BitOffs>
+            <BitOffs>633579776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -68158,7 +67380,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663104</BitOffs>
+            <BitOffs>633579904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -68172,7 +67394,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663136</BitOffs>
+            <BitOffs>633579936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -68186,7 +67408,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663168</BitOffs>
+            <BitOffs>633579968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -68200,7 +67422,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663232</BitOffs>
+            <BitOffs>633580032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -68215,68 +67437,21 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663296</BitOffs>
+            <BitOffs>633580096</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_GVL.stAttenuators</Name>
-            <BitSize>64</BitSize>
-            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
+            <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
             <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.xAttOK</Name>
-                <Value>1</Value>
-              </SubItem>
+              <Value>16</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633663392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cst0RateBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)0RateBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC 0-rate beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633665152</BitOffs>
+            <BitOffs>633580128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -68301,7 +67476,68 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633666912</BitOffs>
+            <BitOffs>633580144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stAttenuators</Name>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.xAttOK</Name>
+                <Value>1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633580160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633580224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633581984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -68316,7 +67552,21 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633666928</BitOffs>
+            <BitOffs>633583744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_cBoundaries</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>31</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633583760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -68335,36 +67585,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633666944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.g_cBoundaries</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>31</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633667968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
-            <Comment> Max fast faults for an FFO</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>50</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633667984</BitOffs>
+            <BitOffs>633583776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -68391,7 +67612,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633668000</BitOffs>
+            <BitOffs>633584800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -68546,7 +67767,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633668032</BitOffs>
+            <BitOffs>633584832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -68701,7 +67922,36 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633669056</BitOffs>
+            <BitOffs>633585856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
+            <Comment> Max fast faults for an FFO</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>50</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633586880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.nCTRL_LOGGER_DATA_ARRAY_SIZE</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633586896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -68716,7 +67966,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633670080</BitOffs>
+            <BitOffs>633586912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -68731,7 +67981,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633670112</BitOffs>
+            <BitOffs>633586944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -68742,7 +67992,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633670144</BitOffs>
+            <BitOffs>633586976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -68782,7 +68032,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633670400</BitOffs>
+            <BitOffs>633587232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -68793,22 +68043,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633670688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoRange</Name>
-            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>60</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633677664</BitOffs>
+            <BitOffs>633587520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -68822,7 +68057,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633677696</BitOffs>
+            <BitOffs>633594496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -68836,7 +68071,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633677760</BitOffs>
+            <BitOffs>633594560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -68872,7 +68107,22 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633677824</BitOffs>
+            <BitOffs>633594624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoRange</Name>
+            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>60</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633594912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
@@ -68887,7 +68137,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633678144</BitOffs>
+            <BitOffs>633594944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMaxVoltage</Name>
@@ -68902,7 +68152,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633678208</BitOffs>
+            <BitOffs>633595008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMinVoltage</Name>
@@ -68917,7 +68167,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633678272</BitOffs>
+            <BitOffs>633595072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
@@ -68946,7 +68196,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633678336</BitOffs>
+            <BitOffs>633595136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
@@ -68986,33 +68236,7 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633680832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.nCTRL_LOGGER_DATA_ARRAY_SIZE</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>633681120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR1L4PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>633681136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bMR2L3PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>633681144</BitOffs>
+            <BitOffs>633597632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.stCtrl_GLOBAL_CycleTimeInterpretation</Name>
@@ -69023,13 +68247,13 @@ Beckhoff</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633681152</BitOffs>
+            <BitOffs>633597952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams_MR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>633826656</BitOffs>
+            <BitOffs>633743232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_MR1L3</Name>
@@ -69042,13 +68266,13 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>633826720</BitOffs>
+            <BitOffs>633743296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams_MR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>633936576</BitOffs>
+            <BitOffs>633853152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_MR2L3</Name>
@@ -69061,13 +68285,13 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>633936640</BitOffs>
+            <BitOffs>633853216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams_MR2L4</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>634046496</BitOffs>
+            <BitOffs>633963072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_MR2L4</Name>
@@ -69080,13 +68304,13 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>634046560</BitOffs>
+            <BitOffs>633963136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>634046784</BitOffs>
+            <BitOffs>633963360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRstM1</Name>
@@ -69099,7 +68323,7 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>634046848</BitOffs>
+            <BitOffs>633963424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRstM2</Name>
@@ -69112,7 +68336,7 @@ Beckhoff</Comment>
                 <Value>2000</Value>
               </SubItem>
             </Default>
-            <BitOffs>634047072</BitOffs>
+            <BitOffs>633963648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.tpImAPLC</Name>
@@ -69124,7 +68348,31 @@ Beckhoff</Comment>
                 <Value>10000</Value>
               </SubItem>
             </Default>
-            <BitOffs>634060928</BitOffs>
+            <BitOffs>633977504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR1L3PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>633977696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR1L4PitchDone</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>633977704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR1L4PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>633977712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bMR2L3PitchDone</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>633977720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -69165,13 +68413,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>634061120</BitOffs>
+            <BitOffs>633977728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>634082368</BitOffs>
+            <BitOffs>633998976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -69204,13 +68452,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>634381760</BitOffs>
+            <BitOffs>634298368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>634403008</BitOffs>
+            <BitOffs>634319616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -69244,13 +68492,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>634702400</BitOffs>
+            <BitOffs>634619008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>634723648</BitOffs>
+            <BitOffs>634640256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -69283,13 +68531,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635023040</BitOffs>
+            <BitOffs>634939648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635044288</BitOffs>
+            <BitOffs>634960896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -69324,13 +68572,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635343680</BitOffs>
+            <BitOffs>635260288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m5</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635364928</BitOffs>
+            <BitOffs>635281536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -69365,13 +68613,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635664320</BitOffs>
+            <BitOffs>635580928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635685568</BitOffs>
+            <BitOffs>635602176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L3</Name>
@@ -69394,11 +68642,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635984960</BitOffs>
+            <BitOffs>635901568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3GantryStats</Name>
-            <BitSize>450752</BitSize>
+            <BitSize>450496</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_HomsStats</BaseType>
             <Properties>
               <Property>
@@ -69408,12 +68656,12 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>636005632</BitOffs>
+            <BitOffs>635922240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbYRMSErrorMR1L3</Name>
             <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -69423,23 +68671,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>636456384</BitOffs>
+            <BitOffs>636372736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>636843392</BitOffs>
+            <BitOffs>636759616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinYRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>636843456</BitOffs>
+            <BitOffs>636759680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbXRMSErrorMR1L3</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -69449,23 +68697,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>636843520</BitOffs>
+            <BitOffs>636759744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>637230528</BitOffs>
+            <BitOffs>637146624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinXRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>637230592</BitOffs>
+            <BitOffs>637146688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbPitchRMSErrorMR1L3</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -69475,23 +68723,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>637230656</BitOffs>
+            <BitOffs>637146752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPitchRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>637617664</BitOffs>
+            <BitOffs>637533632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinPitchRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>637617728</BitOffs>
+            <BitOffs>637533696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderRMSErrorMR1L3</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -69501,33 +68749,33 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>637617792</BitOffs>
+            <BitOffs>637533760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBenderRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638004800</BitOffs>
+            <BitOffs>637920640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinBenderRMSErrorMR1L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638004864</BitOffs>
+            <BitOffs>637920704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L3PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>366848</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>638004928</BitOffs>
+            <BitOffs>637920768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderMR1L3</Name>
             <Comment> Bender Control</Comment>
             <BitSize>128</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
-            <BitOffs>638371776</BitOffs>
+            <BitOffs>638287616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYupMR1L3</Name>
@@ -69544,7 +68792,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638371904</BitOffs>
+            <BitOffs>638287744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYdwnMR1L3</Name>
@@ -69560,7 +68808,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638371936</BitOffs>
+            <BitOffs>638287776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXupMR1L3</Name>
@@ -69576,7 +68824,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638371968</BitOffs>
+            <BitOffs>638287808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXdwnMR1L3</Name>
@@ -69592,7 +68840,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638372000</BitOffs>
+            <BitOffs>638287840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntPitchMR1L3</Name>
@@ -69608,7 +68856,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638372032</BitOffs>
+            <BitOffs>638287872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYupMR1L3</Name>
@@ -69625,7 +68873,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638372064</BitOffs>
+            <BitOffs>638287904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYdwnMR1L3</Name>
@@ -69641,7 +68889,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638372096</BitOffs>
+            <BitOffs>638287936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXupMR1L3</Name>
@@ -69657,7 +68905,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638372128</BitOffs>
+            <BitOffs>638287968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXdwnMR1L3</Name>
@@ -69673,7 +68921,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638372160</BitOffs>
+            <BitOffs>638288000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefPitchMR1L3</Name>
@@ -69689,20 +68937,20 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638372192</BitOffs>
+            <BitOffs>638288032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.mcReadParameterPitchMR1L3</Name>
             <BitSize>4288</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>638372224</BitOffs>
+            <BitOffs>638288064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fEncRefPitchMR1L3_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638376512</BitOffs>
+            <BitOffs>638292352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -69738,13 +68986,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638376576</BitOffs>
+            <BitOffs>638292416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m7</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>638397824</BitOffs>
+            <BitOffs>638313664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -69777,13 +69025,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638697216</BitOffs>
+            <BitOffs>638613056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m8</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>638718464</BitOffs>
+            <BitOffs>638634304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -69817,13 +69065,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639017856</BitOffs>
+            <BitOffs>638933696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m9</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>639039104</BitOffs>
+            <BitOffs>638954944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -69856,13 +69104,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639338496</BitOffs>
+            <BitOffs>639254336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m10</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>639359744</BitOffs>
+            <BitOffs>639275584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -69897,13 +69145,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639659136</BitOffs>
+            <BitOffs>639574976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m11</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>639680384</BitOffs>
+            <BitOffs>639596224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -69938,13 +69186,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>639979776</BitOffs>
+            <BitOffs>639895616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>640001024</BitOffs>
+            <BitOffs>639916864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR1L4</Name>
@@ -69967,11 +69215,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>640300416</BitOffs>
+            <BitOffs>640216256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4GantryStats</Name>
-            <BitSize>450752</BitSize>
+            <BitSize>450496</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_HomsStats</BaseType>
             <Properties>
               <Property>
@@ -69981,12 +69229,12 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>640321088</BitOffs>
+            <BitOffs>640236928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbYRMSErrorMR1L4</Name>
             <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -69996,23 +69244,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>640771840</BitOffs>
+            <BitOffs>640687424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>641158848</BitOffs>
+            <BitOffs>641074304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinYRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>641158912</BitOffs>
+            <BitOffs>641074368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbXRMSErrorMR1L4</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -70022,23 +69270,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>641158976</BitOffs>
+            <BitOffs>641074432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>641545984</BitOffs>
+            <BitOffs>641461312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinXRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>641546048</BitOffs>
+            <BitOffs>641461376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbPitchRMSErrorMR1L4</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -70048,23 +69296,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>641546112</BitOffs>
+            <BitOffs>641461440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPitchRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>641933120</BitOffs>
+            <BitOffs>641848320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinPitchRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>641933184</BitOffs>
+            <BitOffs>641848384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderRMSErrorMR1L4</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -70074,33 +69322,33 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>641933248</BitOffs>
+            <BitOffs>641848448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBenderRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642320256</BitOffs>
+            <BitOffs>642235328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinBenderRMSErrorMR1L4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642320320</BitOffs>
+            <BitOffs>642235392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR1L4PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>366848</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>642320384</BitOffs>
+            <BitOffs>642235456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderMR1L4</Name>
             <Comment> Bender Control</Comment>
             <BitSize>128</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
-            <BitOffs>642687232</BitOffs>
+            <BitOffs>642602304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYupMR1L4</Name>
@@ -70117,7 +69365,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687360</BitOffs>
+            <BitOffs>642602432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYdwnMR1L4</Name>
@@ -70133,7 +69381,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687392</BitOffs>
+            <BitOffs>642602464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXupMR1L4</Name>
@@ -70149,7 +69397,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687424</BitOffs>
+            <BitOffs>642602496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXdwnMR1L4</Name>
@@ -70165,7 +69413,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687456</BitOffs>
+            <BitOffs>642602528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntPitchMR1L4</Name>
@@ -70181,7 +69429,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687488</BitOffs>
+            <BitOffs>642602560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYupMR1L4</Name>
@@ -70198,7 +69446,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687520</BitOffs>
+            <BitOffs>642602592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYdwnMR1L4</Name>
@@ -70214,7 +69462,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687552</BitOffs>
+            <BitOffs>642602624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXupMR1L4</Name>
@@ -70230,7 +69478,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687584</BitOffs>
+            <BitOffs>642602656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXdwnMR1L4</Name>
@@ -70246,7 +69494,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687616</BitOffs>
+            <BitOffs>642602688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefPitchMR1L4</Name>
@@ -70262,20 +69510,20 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642687648</BitOffs>
+            <BitOffs>642602720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.mcReadParameterPitchMR1L4</Name>
             <BitSize>4288</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>642687680</BitOffs>
+            <BitOffs>642602752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fEncRefPitchMR1L4_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>642691968</BitOffs>
+            <BitOffs>642607040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -70309,13 +69557,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642692032</BitOffs>
+            <BitOffs>642607104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>642713280</BitOffs>
+            <BitOffs>642628352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -70349,13 +69597,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643012672</BitOffs>
+            <BitOffs>642927744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>643033920</BitOffs>
+            <BitOffs>642948992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -70390,13 +69638,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643333312</BitOffs>
+            <BitOffs>643248384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>643354560</BitOffs>
+            <BitOffs>643269632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -70430,13 +69678,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643653952</BitOffs>
+            <BitOffs>643569024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m16</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>643675200</BitOffs>
+            <BitOffs>643590272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -70471,13 +69719,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>643974592</BitOffs>
+            <BitOffs>643889664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>643995840</BitOffs>
+            <BitOffs>643910912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -70512,13 +69760,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>644295232</BitOffs>
+            <BitOffs>644210304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
             <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>644316480</BitOffs>
+            <BitOffs>644231552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.MR2L3</Name>
@@ -70541,11 +69789,11 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>644615872</BitOffs>
+            <BitOffs>644530944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3GantryStats</Name>
-            <BitSize>450752</BitSize>
+            <BitSize>450496</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_HomsStats</BaseType>
             <Properties>
               <Property>
@@ -70555,12 +69803,12 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>644636544</BitOffs>
+            <BitOffs>644551616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbYRMSErrorMR2L3</Name>
             <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -70570,23 +69818,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>645087296</BitOffs>
+            <BitOffs>645002112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>645474304</BitOffs>
+            <BitOffs>645388992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinYRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>645474368</BitOffs>
+            <BitOffs>645389056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbXRMSErrorMR2L3</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -70596,23 +69844,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>645474432</BitOffs>
+            <BitOffs>645389120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>645861440</BitOffs>
+            <BitOffs>645776000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinXRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>645861504</BitOffs>
+            <BitOffs>645776064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbPitchRMSErrorMR2L3</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -70622,23 +69870,23 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>645861568</BitOffs>
+            <BitOffs>645776128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPitchRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646248576</BitOffs>
+            <BitOffs>646163008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinPitchRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646248640</BitOffs>
+            <BitOffs>646163072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderRMSErrorMR2L3</Name>
-            <BitSize>387008</BitSize>
+            <BitSize>386880</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
@@ -70648,57 +69896,57 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>646248704</BitOffs>
+            <BitOffs>646163136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBenderRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646635712</BitOffs>
+            <BitOffs>646550016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMinBenderRMSErrorMR2L3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>646635776</BitOffs>
+            <BitOffs>646550080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMR2L3PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>366848</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>646635840</BitOffs>
+            <BitOffs>646550144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.bMR2L3PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>647002688</BitOffs>
+            <BitOffs>646916992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.bMR1L3_OUT_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>647002696</BitOffs>
+            <BitOffs>646917000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.bRemove</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>647002704</BitOffs>
+            <BitOffs>646917008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.bExist</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>647002712</BitOffs>
+            <BitOffs>646917016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBenderMR2L3</Name>
             <Comment> Bender Control</Comment>
             <BitSize>128</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
-            <BitOffs>647002720</BitOffs>
+            <BitOffs>646917024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYupMR2L3</Name>
@@ -70715,7 +69963,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647002848</BitOffs>
+            <BitOffs>646917152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYdwnMR2L3</Name>
@@ -70731,7 +69979,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647002880</BitOffs>
+            <BitOffs>646917184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXupMR2L3</Name>
@@ -70747,7 +69995,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647002912</BitOffs>
+            <BitOffs>646917216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntXdwnMR2L3</Name>
@@ -70763,7 +70011,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647002944</BitOffs>
+            <BitOffs>646917248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntPitchMR2L3</Name>
@@ -70779,7 +70027,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647002976</BitOffs>
+            <BitOffs>646917280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYupMR2L3</Name>
@@ -70796,7 +70044,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647003008</BitOffs>
+            <BitOffs>646917312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefYdwnMR2L3</Name>
@@ -70812,7 +70060,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647003040</BitOffs>
+            <BitOffs>646917344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXupMR2L3</Name>
@@ -70828,7 +70076,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647003072</BitOffs>
+            <BitOffs>646917376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefXdwnMR2L3</Name>
@@ -70844,7 +70092,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647003104</BitOffs>
+            <BitOffs>646917408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncRefPitchMR2L3</Name>
@@ -70860,26 +70108,26 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>647003136</BitOffs>
+            <BitOffs>646917440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.nReq</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
-            <BitOffs>647003168</BitOffs>
+            <BitOffs>646917472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.mcReadParameterPitchMR2L3</Name>
             <BitSize>4288</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>647003200</BitOffs>
+            <BitOffs>646917504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fEncRefPitchMR2L3_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>647007488</BitOffs>
+            <BitOffs>646921792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fEncLeverArm_mm</Name>
@@ -70889,14 +70137,14 @@ PMPS State Stage; bPowerSelf:=False</Comment>
             <Default>
               <Value>513</Value>
             </Default>
-            <BitOffs>647007552</BitOffs>
+            <BitOffs>646921856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbLogHandler</Name>
             <Comment> Logging</Comment>
             <BitSize>5784896</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>647007616</BitOffs>
+            <BitOffs>646921920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L3_Coating_States</Name>
@@ -70912,19 +70160,19 @@ PMPS State Stage; bPowerSelf:=False</Comment>
      </Value>
               </Property>
             </Properties>
-            <BitOffs>652829824</BitOffs>
+            <BitOffs>652744128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_SiC</Name>
             <BitSize>2944</BitSize>
             <BaseType Namespace="lcls_twincat_motion">DUT_PositionState</BaseType>
-            <BitOffs>653302592</BitOffs>
+            <BitOffs>653216896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_W</Name>
             <BitSize>2944</BitSize>
             <BaseType Namespace="lcls_twincat_motion">DUT_PositionState</BaseType>
-            <BitOffs>653305536</BitOffs>
+            <BitOffs>653219840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L3_InOut_States</Name>
@@ -70939,7 +70187,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653308480</BitOffs>
+            <BitOffs>653222784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_In</Name>
@@ -70975,7 +70223,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>653545792</BitOffs>
+            <BitOffs>653460096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L3_Out</Name>
@@ -71011,7 +70259,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>653548736</BitOffs>
+            <BitOffs>653463040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR2L3_Coating_States</Name>
@@ -71027,7 +70275,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653551680</BitOffs>
+            <BitOffs>653465984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR2L3_SiC</Name>
@@ -71063,7 +70311,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>653788992</BitOffs>
+            <BitOffs>653703296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR2L3_W</Name>
@@ -71099,7 +70347,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>653791936</BitOffs>
+            <BitOffs>653706240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L4_Coating_States</Name>
@@ -71115,7 +70363,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653794880</BitOffs>
+            <BitOffs>653709184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_SiC</Name>
@@ -71151,7 +70399,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654032192</BitOffs>
+            <BitOffs>653946496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_W</Name>
@@ -71187,7 +70435,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654035136</BitOffs>
+            <BitOffs>653949440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.fbMR1L4_InOut_States</Name>
@@ -71202,7 +70450,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654038080</BitOffs>
+            <BitOffs>653952384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_In</Name>
@@ -71238,7 +70486,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654275392</BitOffs>
+            <BitOffs>654189696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_States.MR1L4_Out</Name>
@@ -71274,7 +70522,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>150</Value>
               </SubItem>
             </Default>
-            <BitOffs>654278336</BitOffs>
+            <BitOffs>654192640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.fbM1</Name>
@@ -71315,7 +70563,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>654281472</BitOffs>
+            <BitOffs>654195776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.fbM2</Name>
@@ -71356,7 +70604,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>654334048</BitOffs>
+            <BitOffs>654248352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.fbM3</Name>
@@ -71397,7 +70645,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>654386624</BitOffs>
+            <BitOffs>654300928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CoatingProtection.ffM1M2IN</Name>
@@ -71418,13 +70666,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>1538</Value>
               </SubItem>
             </Default>
-            <BitOffs>654439200</BitOffs>
+            <BitOffs>654353504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>654464288</BitOffs>
+            <BitOffs>654378592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.ff2_ff1_link_vac</Name>
@@ -71448,13 +70696,13 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Value>39321</Value>
               </SubItem>
             </Default>
-            <BitOffs>654491456</BitOffs>
+            <BitOffs>654405760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PMPS.rtRemove</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>654516544</BitOffs>
+            <BitOffs>654430848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gDefaultSubsystem</Name>
@@ -71468,7 +70716,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517280</BitOffs>
+            <BitOffs>654431584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gSystemFault</Name>
@@ -71479,7 +70727,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517296</BitOffs>
+            <BitOffs>654431600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gFirstPass</Name>
@@ -71493,7 +70741,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517304</BitOffs>
+            <BitOffs>654431608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.g_psLogHost</Name>
@@ -71507,7 +70755,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517376</BitOffs>
+            <BitOffs>654431680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gM1STO</Name>
@@ -71519,7 +70767,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517568</BitOffs>
+            <BitOffs>654431872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gM2STO</Name>
@@ -71530,7 +70778,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517576</BitOffs>
+            <BitOffs>654431880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gM3STO</Name>
@@ -71541,7 +70789,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517584</BitOffs>
+            <BitOffs>654431888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gBypassVirtualLimits</Name>
@@ -71553,7 +70801,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517592</BitOffs>
+            <BitOffs>654431896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -71568,7 +70816,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517608</BitOffs>
+            <BitOffs>654431912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -71583,7 +70831,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517616</BitOffs>
+            <BitOffs>654431920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -71598,7 +70846,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517624</BitOffs>
+            <BitOffs>654431928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.gEncScale</Name>
@@ -71614,7 +70862,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654517632</BitOffs>
+            <BitOffs>654431936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -71629,7 +70877,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654532768</BitOffs>
+            <BitOffs>654447072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -71644,7 +70892,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654532784</BitOffs>
+            <BitOffs>654447088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMaxVoltage</Name>
@@ -71658,7 +70906,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654532800</BitOffs>
+            <BitOffs>654447104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMinVoltage</Name>
@@ -71672,7 +70920,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654532864</BitOffs>
+            <BitOffs>654447168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nYUP_ENC_REF</Name>
@@ -71688,7 +70936,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654535424</BitOffs>
+            <BitOffs>654449728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nYDWN_ENC_REF</Name>
@@ -71702,7 +70950,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654535488</BitOffs>
+            <BitOffs>654449792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nXUP_ENC_REF</Name>
@@ -71716,7 +70964,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654535552</BitOffs>
+            <BitOffs>654449856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L4_Constants.nXDWN_ENC_REF</Name>
@@ -71730,7 +70978,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654535616</BitOffs>
+            <BitOffs>654449920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nYUP_ENC_REF</Name>
@@ -71746,7 +70994,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538176</BitOffs>
+            <BitOffs>654452480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nYDWN_ENC_REF</Name>
@@ -71760,7 +71008,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538240</BitOffs>
+            <BitOffs>654452544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nXUP_ENC_REF</Name>
@@ -71774,7 +71022,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538304</BitOffs>
+            <BitOffs>654452608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR1L3_Constants.nXDWN_ENC_REF</Name>
@@ -71788,7 +71036,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538368</BitOffs>
+            <BitOffs>654452672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nYUP_ENC_REF</Name>
@@ -71804,7 +71052,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538432</BitOffs>
+            <BitOffs>654452736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nYDWN_ENC_REF</Name>
@@ -71818,7 +71066,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538496</BitOffs>
+            <BitOffs>654452800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nXUP_ENC_REF</Name>
@@ -71832,7 +71080,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538560</BitOffs>
+            <BitOffs>654452864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_MR2L3_Constants.nXDWN_ENC_REF</Name>
@@ -71846,7 +71094,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654538624</BitOffs>
+            <BitOffs>654452928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput1</Name>
@@ -71873,7 +71121,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>654541184</BitOffs>
+            <BitOffs>654455488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2</Name>
@@ -71900,7 +71148,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655036480</BitOffs>
+            <BitOffs>654950784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter1</Name>
@@ -71920,7 +71168,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>655531776</BitOffs>
+            <BitOffs>655446080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter2</Name>
@@ -71940,7 +71188,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656006400</BitOffs>
+            <BitOffs>655920704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiterIO</Name>
@@ -71952,7 +71200,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656481024</BitOffs>
+            <BitOffs>656395328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_1</Name>
@@ -71979,7 +71227,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656619776</BitOffs>
+            <BitOffs>656534080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_2</Name>
@@ -72005,7 +71253,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656620032</BitOffs>
+            <BitOffs>656534336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L3_Env_RTD_3</Name>
@@ -72031,7 +71279,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656620288</BitOffs>
+            <BitOffs>656534592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_1</Name>
@@ -72058,7 +71306,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656620544</BitOffs>
+            <BitOffs>656534848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_2</Name>
@@ -72084,7 +71332,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656620800</BitOffs>
+            <BitOffs>656535104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR2L3_Env_RTD_3</Name>
@@ -72110,7 +71358,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656621056</BitOffs>
+            <BitOffs>656535360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_1</Name>
@@ -72137,7 +71385,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656621312</BitOffs>
+            <BitOffs>656535616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_2</Name>
@@ -72163,7 +71411,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656621568</BitOffs>
+            <BitOffs>656535872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_RTDS.fbMR1L4_Env_RTD_3</Name>
@@ -72189,7 +71437,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656621824</BitOffs>
+            <BitOffs>656536128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -72219,7 +71467,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656623232</BitOffs>
+            <BitOffs>656537536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -72249,7 +71497,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656623296</BitOffs>
+            <BitOffs>656537600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -72264,7 +71512,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656623360</BitOffs>
+            <BitOffs>656537664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -72279,7 +71527,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656623392</BitOffs>
+            <BitOffs>656537696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -72293,7 +71541,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656623424</BitOffs>
+            <BitOffs>656537728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -72414,7 +71662,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656623456</BitOffs>
+            <BitOffs>656537760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -72432,7 +71680,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656627584</BitOffs>
+            <BitOffs>656541888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -72446,7 +71694,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656630752</BitOffs>
+            <BitOffs>656545056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -72460,7 +71708,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656630784</BitOffs>
+            <BitOffs>656545088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -72481,7 +71729,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656632224</BitOffs>
+            <BitOffs>656546528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -72553,7 +71801,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656649824</BitOffs>
+            <BitOffs>656564128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -72625,7 +71873,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656649952</BitOffs>
+            <BitOffs>656564256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -72697,7 +71945,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656650080</BitOffs>
+            <BitOffs>656564384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -72769,7 +72017,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656650208</BitOffs>
+            <BitOffs>656564512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -72841,7 +72089,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656650336</BitOffs>
+            <BitOffs>656564640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -72913,7 +72161,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656650464</BitOffs>
+            <BitOffs>656564768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -72939,7 +72187,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>656683616</BitOffs>
+            <BitOffs>656597920</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -72964,7 +72212,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663008</BitOffs>
+            <BitOffs>633579808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AccumulatedFF</Name>
@@ -72983,7 +72231,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663040</BitOffs>
+            <BitOffs>633579840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.BP_jsonDoc</Name>
@@ -72994,7 +72242,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633663072</BitOffs>
+            <BitOffs>633579872</BitOffs>
           </Symbol>
         </DataArea>
       </DataAreas>
@@ -73026,15 +72274,15 @@ PMPS State Stage; bPowerSelf:=False</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-04-25T09:40:57</Value>
+          <Value>2024-05-08T15:34:15</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>692224</Value>
+          <Value>684032</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>81788928</Value>
+          <Value>81776640</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Went to release this project and got:
```
ERROR:pytmc.bin.db:Duplicate records encountered:
    $(PREFIX)LCLSGeneral:GlobalLogTrickleTrip_RBV (2)
    $(PREFIX)LCLSGeneral:LogHost (2)
    $(PREFIX)LCLSGeneral:LogHost_RBV (2)
    $(PREFIX)LCLSGeneral:LogMessageCount_RBV (2)
    $(PREFIX)LCLSGeneral:LogPort (2)
    $(PREFIX)LCLSGeneral:LogPort_RBV (2)
```
Found place holder for LCLSGeneral set to *, set to 2.8.2, same as project.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
